### PR TITLE
Show error message for expired node key

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -141,7 +141,7 @@ export async function activate(context: vscode.ExtensionContext) {
       }
 
       const status = await tailscaleInstance.serveStatus();
-      if (status?.Errors && status.Errors.length > 0) {
+      if (status?.Errors?.length) {
         status.Errors.map((err) => {
           const e = errorForType(err.Type);
 
@@ -161,8 +161,6 @@ export async function activate(context: vscode.ExtensionContext) {
               }
             });
         });
-
-        return status;
       } else {
         tailscaleInstance.runFunnel(parseInt(port));
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,14 +19,9 @@ export interface Handlers {
   Proxy: string;
 }
 
-export interface ServeStatus extends RelayStatus {
+export interface ServeStatus {
   ServeConfig?: ServeConfig;
-  FunnelOff?: boolean;
-  NeedsHTTPs?: boolean;
   FunnelPorts?: number[];
-}
-
-interface RelayStatus {
   BackendState: string;
   Self: PeerStatus;
   Errors?: RelayError[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,11 +31,6 @@ interface RelayError {
   Type: string;
 }
 
-interface RelayErrorLink {
-  title: string;
-  url: string;
-}
-
 interface PeerStatus {
   DNSName: string;
   Online: boolean;

--- a/tsrelay/main.go
+++ b/tsrelay/main.go
@@ -124,8 +124,6 @@ type serveStatus struct {
 	ServeConfig  *ipn.ServeConfig
 	BackendState string
 	Self         *peerStatus
-	FunnelOff    bool
-	NeedsHTTPs   bool
 	FunnelPorts  []int
 	Errors       []Error `json:",omitempty"`
 }


### PR DESCRIPTION
This PR does a couple of things: 

1. Sets the OFFLINE error when key is expired. We can potentially make it a special message. 
2. It also adds a socket path for extension development if we need it to point to a different localapi or server. 