### PR TITLE
ci: Fix branch label mapping for backport

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -5,7 +5,7 @@
   "targetBranchChoices": ["release-branch/v0.4"],
 
   "branchLabelMapping": {
-    "^v(\\d+).(\\d+).\\d+$": "release-branch/v$1.$2"
+    "^v(\\d+).(\\d+)": "release-branch/v$1.$2"
   },
 
   "fork": false,


### PR DESCRIPTION
Versions should be `major.minor`.

Resolves backport Github action failing: https://github.com/tailscale-dev/vscode-tailscale/actions/runs/5203821591