### PR TITLE
[release-branch/v0.4] Show error message for expired node key (#1)

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -141,7 +141,7 @@ export async function activate(context: vscode.ExtensionContext) {
       }
 
       const status = await tailscaleInstance.serveStatus();
-      if (status?.Errors && status.Errors.length > 0) {
+      if (status?.Errors?.length) {
         status.Errors.map((err) => {
           const e = errorForType(err.Type);
 
@@ -161,8 +161,6 @@ export async function activate(context: vscode.ExtensionContext) {
               }
             });
         });
-
-        return status;
       } else {
         tailscaleInstance.runFunnel(parseInt(port));
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,14 +19,9 @@ export interface Handlers {
   Proxy: string;
 }
 
-export interface ServeStatus extends RelayStatus {
+export interface ServeStatus {
   ServeConfig?: ServeConfig;
-  FunnelOff?: boolean;
-  NeedsHTTPs?: boolean;
   FunnelPorts?: number[];
-}
-
-interface RelayStatus {
   BackendState: string;
   Self: PeerStatus;
   Errors?: RelayError[];
@@ -34,11 +29,6 @@ interface RelayStatus {
 
 interface RelayError {
   Type: string;
-}
-
-interface RelayErrorLink {
-  title: string;
-  url: string;
 }
 
 interface PeerStatus {

--- a/tsrelay/main.go
+++ b/tsrelay/main.go
@@ -33,6 +33,22 @@ var (
 	verbose = flag.Bool("v", false, "verbose logging")
 	port    = flag.Int("port", 0, "port for http server. If 0, one will be chosen")
 	nonce   = flag.String("nonce", "", "nonce for the http server")
+	socket  = flag.String("socket", "", "alternative path for local api socket")
+)
+
+// ErrorTypes for signaling
+// invalid states to the VSCode
+// extension.
+const (
+	// FunnelOff means the user does not have
+	// funnel in their ACLs.
+	FunnelOff = "FUNNEL_OFF"
+	// HTTPSOff means the user has not enabled
+	// https in the DNS section of the UI
+	HTTPSOff = "HTTPS_OFF"
+	// Offline can mean a user is not logged in
+	// or is logged in but their key has expired.
+	Offline = "OFFLINE"
 )
 
 func main() {
@@ -76,6 +92,9 @@ func runHTTPServer(ctx context.Context, lggr *logger, port int, nonce string) er
 	fmt.Fprintf(os.Stdout, "http://127.0.0.1:%s\n", u.Port())
 	s := &http.Server{
 		Handler: &httpHandler{
+			lc: tailscale.LocalClient{
+				Socket: *socket,
+			},
 			nonce:        nonce,
 			l:            lggr,
 			pids:         make(map[int]struct{}),
@@ -105,8 +124,6 @@ type serveStatus struct {
 	ServeConfig  *ipn.ServeConfig
 	BackendState string
 	Self         *peerStatus
-	FunnelOff    bool
-	NeedsHTTPs   bool
 	FunnelPorts  []int
 	Errors       []Error `json:",omitempty"`
 }
@@ -217,17 +234,17 @@ func (h *httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				if slices.Contains(capabilities, tailcfg.CapabilityWarnFunnelNoInvite) ||
 					!slices.Contains(capabilities, tailcfg.NodeAttrFunnel) {
 					s.Errors = append(s.Errors, Error{
-						Type: "FUNNEL_OFF",
+						Type: FunnelOff,
 					})
 				}
 				if slices.Contains(capabilities, tailcfg.CapabilityWarnFunnelNoHTTPS) {
 					s.Errors = append(s.Errors, Error{
-						Type: "HTTPS_OFF",
+						Type: HTTPSOff,
 					})
 				}
-				if !st.Self.Online {
+				if !st.Self.Online || s.BackendState == "NeedsLogin" {
 					s.Errors = append(s.Errors, Error{
-						Type: "OFFLINE",
+						Type: Offline,
 					})
 				}
 			}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release-branch/v0.4`:
 - [Show error message for expired node key (#1)](https://github.com/tailscale-dev/vscode-tailscale/pull/1)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)