### PR TITLE
Output server details as json

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -152,3 +152,8 @@ export interface NewPortNotification {
   message: string;
   port: number;
 }
+
+export interface TSRelayDetails {
+  address: string;
+  nonce: string;
+}


### PR DESCRIPTION
This PR changes the address url stdout to be in json format and lets tsrelay come up with its own once by default. This way, we can add more details that a client such as vscode might need to extract out of tsrelay at server startup. 