### PR TITLE
src/tailscale/cli: fix go path for development mode

### DIFF
--- a/src/tailscale/cli.ts
+++ b/src/tailscale/cli.ts
@@ -62,7 +62,7 @@ export class Tailscale {
       }
       let cwd = __dirname;
       if (process.env.NODE_ENV === 'development') {
-        binPath = 'go';
+        binPath = '../tool/go';
         args = ['run', '.', ...args];
         cwd = path.join(cwd, '../tsrelay');
       }


### PR DESCRIPTION
Use ./tool/go for development mode instead of go. This allows the development mode to work when the go binary is not in the PATH.

Fixes #66