### PR TITLE
DX: Disable other extensions in development

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
       "name": "Run Extension",
       "type": "extensionHost",
       "request": "launch",
-      "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
+      "args": ["--extensionDevelopmentPath=${workspaceFolder}", "--disable-extensions"],
       "env": {
         "NODE_ENV": "development"
       },


### PR DESCRIPTION
When debugging the extension, we can run VS Code with "--disable-extensions" to prevent any extensions on the host from being run.