### PR TITLE
Run flatpak-spawn when pkexec is needed

### DIFF
--- a/src/tailscale/cli.ts
+++ b/src/tailscale/cli.ts
@@ -158,7 +158,8 @@ export class Tailscale {
         let authArgs = ['--disable-internal-agent', binPath, ...args];
         if (
           process.env['container'] === 'flatpak' &&
-          process.env['FLATPAK_ID'] === 'com.visualstudio.code'
+          process.env['FLATPAK_ID'] &&
+          process.env['FLATPAK_ID'].startsWith('com.visualstudio.code')
         ) {
           authCmd = 'flatpak-spawn';
           authArgs = ['--host', 'pkexec', '--disable-internal-agent', binPath, ...args];

--- a/src/tailscale/error.ts
+++ b/src/tailscale/error.ts
@@ -43,6 +43,11 @@ export function errorForType(type: string): TailscaleError {
           },
         ],
       };
+    case 'REQUIRES_RESTART':
+      return {
+        title: 'Restart Flatpak Container',
+        message: 'Please quit VSCode and restart the container to finish setting up Tailscale',
+      };
     default:
       return {
         title: 'Unknown error',

--- a/src/tailscale/error.ts
+++ b/src/tailscale/error.ts
@@ -43,7 +43,7 @@ export function errorForType(type: string): TailscaleError {
           },
         ],
       };
-    case 'REQUIRES_RESTART':
+    case 'FLATPAK_REQUIRES_RESTART':
       return {
         title: 'Restart Flatpak Container',
         message: 'Please quit VSCode and restart the container to finish setting up Tailscale',

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,7 +34,13 @@ export interface WithErrors {
 }
 
 interface RelayError {
-  Type: 'FUNNEL_OFF' | 'HTTPS_OFF' | 'OFFLINE' | 'REQUIRES_SUDO' | 'NOT_RUNNING';
+  Type:
+    | 'FUNNEL_OFF'
+    | 'HTTPS_OFF'
+    | 'OFFLINE'
+    | 'REQUIRES_SUDO'
+    | 'NOT_RUNNING'
+    | 'REQUIRES_RESTART';
 }
 
 interface PeerStatus {

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,14 +33,14 @@ export interface WithErrors {
   Errors?: RelayError[];
 }
 
-interface RelayError {
+export interface RelayError {
   Type:
     | 'FUNNEL_OFF'
     | 'HTTPS_OFF'
     | 'OFFLINE'
     | 'REQUIRES_SUDO'
     | 'NOT_RUNNING'
-    | 'REQUIRES_RESTART';
+    | 'FLATPAK_REQUIRES_RESTART';
 }
 
 interface PeerStatus {

--- a/tsrelay/main.go
+++ b/tsrelay/main.go
@@ -57,9 +57,9 @@ const (
 	// NotRunning indicates tailscaled is
 	// not running
 	NotRunning = "NOT_RUNNING"
-	// RequiresRestart indicates that the flatpak
+	// FlatpakRequiresRestart indicates that the flatpak
 	// container needs to be fully restarted
-	RequiresRestart = "REQUIRES_RESTART"
+	FlatpakRequiresRestart = "FLATPAK_REQUIRES_RESTART"
 )
 
 var requiresRestart bool
@@ -298,7 +298,7 @@ func (h *httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		case http.MethodGet:
 			if requiresRestart {
 				json.NewEncoder(w).Encode(RelayError{
-					Errors: []Error{{Type: RequiresRestart}},
+					Errors: []Error{{Type: FlatpakRequiresRestart}},
 				})
 				return
 			}


### PR DESCRIPTION
This PR checks the env vars to see if we're running inside of flatpak, and if saw prepends the pkexec with flatpak-spawn in order rerun tsrelay as sudo. 

We also run `flatpak override` so the user doesn't have to. 

Fixes https://github.com/tailscale-dev/vscode-tailscale/issues/76