### PR TITLE
Add ability to mock LocalClient

### DIFF
--- a/profiles/offline.json
+++ b/profiles/offline.json
@@ -1,0 +1,3 @@
+{
+  "MockOffline": true
+}

--- a/profiles/snapshot.mjs
+++ b/profiles/snapshot.mjs
@@ -1,0 +1,60 @@
+import { exec } from 'child_process';
+import fs from 'fs';
+
+function executeCommand(command) {
+  const fullCommand = `tailscale ${command} --json`;
+  return new Promise((resolve, reject) => {
+    exec(fullCommand, (error, stdout, stderr) => {
+      if (error) {
+        // If command not found in PATH, try with zsh
+        if (error.code === 127) {
+          exec(`zsh -i -c "${fullCommand}"`, (zshError, zshStdout, zshStderr) => {
+            if (zshError) {
+              reject(zshError);
+            } else {
+              resolve(JSON.parse(zshStdout.trim()));
+            }
+          });
+        } else {
+          reject(error);
+        }
+      } else {
+        try {
+          const parsedOutput = JSON.parse(stdout.trim());
+          resolve(parsedOutput);
+        } catch (parseError) {
+          resolve({});
+        }
+      }
+    });
+  });
+}
+
+function exportResults(profileName, results) {
+  const filename = `${profileName}.json`;
+  fs.writeFileSync(filename, JSON.stringify(results, null, 2));
+  console.log(`Results exported to ${filename}`);
+}
+
+async function runCommands(profileName) {
+  try {
+    const results = {};
+
+    results.Status = await executeCommand('status');
+    results.ServeConfig = await executeCommand('serve status');
+
+    // Export results to JSON file
+    exportResults(profileName, results);
+  } catch (error) {
+    console.error('Error:', error.message);
+    throw error;
+  }
+}
+
+const profileName = process.argv[2];
+
+if (profileName) {
+  runCommands(profileName);
+} else {
+  console.error('Please provide a profile name as an argument.');
+}

--- a/tsrelay/local_client.go
+++ b/tsrelay/local_client.go
@@ -69,7 +69,7 @@ func (m *mockClient) SetServeConfig(ctx context.Context, config *ipn.ServeConfig
 
 // Status implements localClient.
 func (m *mockClient) Status(ctx context.Context) (*ipnstate.Status, error) {
-	if m.p.MockOffline {
+	if m.p.MockOffline || m.p.Status == nil {
 		return nil, &net.OpError{Op: "dial"}
 	}
 	return m.p.Status, nil
@@ -77,7 +77,7 @@ func (m *mockClient) Status(ctx context.Context) (*ipnstate.Status, error) {
 
 // StatusWithoutPeers implements localClient.
 func (m *mockClient) StatusWithoutPeers(ctx context.Context) (*ipnstate.Status, error) {
-	if m.p.MockOffline {
+	if m.p.MockOffline || m.p.Status == nil {
 		return nil, &net.OpError{Op: "dial"}
 	}
 	copy := *(m.p.Status)

--- a/tsrelay/local_client.go
+++ b/tsrelay/local_client.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"os"
+	"sync"
+
+	"tailscale.com/client/tailscale"
+	"tailscale.com/ipn"
+	"tailscale.com/ipn/ipnstate"
+)
+
+// static check for local client interface implementation
+var _ localClient = (*tailscale.LocalClient)(nil)
+
+// localClient is an abstraction of tailscale.LocalClient
+type localClient interface {
+	Status(ctx context.Context) (*ipnstate.Status, error)
+	GetServeConfig(ctx context.Context) (*ipn.ServeConfig, error)
+	StatusWithoutPeers(ctx context.Context) (*ipnstate.Status, error)
+	SetServeConfig(ctx context.Context, config *ipn.ServeConfig) error
+}
+
+type profile struct {
+	Status           *ipnstate.Status
+	ServeConfig      *ipn.ServeConfig
+	MockOffline      bool
+	MockAccessDenied bool
+}
+
+// NewMockClient returns a mock localClient
+// based on the given json file. The format of the file
+// is described in the profile struct. Note that SET
+// operations update the given input in memory.
+func NewMockClient(file string) (localClient, error) {
+	bts, err := os.ReadFile(file)
+	if err != nil {
+		return nil, err
+	}
+	var p profile
+	return &mockClient{p: &p}, json.Unmarshal(bts, &p)
+}
+
+type mockClient struct {
+	sync.Mutex
+	p *profile
+}
+
+// GetServeConfig implements localClient.
+func (m *mockClient) GetServeConfig(ctx context.Context) (*ipn.ServeConfig, error) {
+	if m.p.MockOffline {
+		return nil, &net.OpError{Op: "dial"}
+	}
+	return m.p.ServeConfig, nil
+}
+
+// SetServeConfig implements localClient.
+func (m *mockClient) SetServeConfig(ctx context.Context, config *ipn.ServeConfig) error {
+	if m.p.MockAccessDenied {
+		return &tailscale.AccessDeniedError{}
+	}
+	m.Lock()
+	defer m.Unlock()
+	m.p.ServeConfig = config
+	return nil
+}
+
+// Status implements localClient.
+func (m *mockClient) Status(ctx context.Context) (*ipnstate.Status, error) {
+	if m.p.MockOffline {
+		return nil, &net.OpError{Op: "dial"}
+	}
+	return m.p.Status, nil
+}
+
+// StatusWithoutPeers implements localClient.
+func (m *mockClient) StatusWithoutPeers(ctx context.Context) (*ipnstate.Status, error) {
+	if m.p.MockOffline {
+		return nil, &net.OpError{Op: "dial"}
+	}
+	copy := *(m.p.Status)
+	copy.Peer = nil
+	return &copy, nil
+}


### PR DESCRIPTION
This PR adds the ability to mock LocalClient responses via `-mockfile` so that we can test vscode <-> tsrelay communication without requiring a live tailscaled server. 