### PR TITLE
Make port discovery optional via settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ You can open the public URL in your default browser or copy it to your clipboard
 
 When you start a local server from VS Code, Tailscale will ask if you'd like to share that port over the internet with Funnel.
 
-You can turn this off in your vscode settings via the `tailscale.portDiscovery` option.
+This functionality can be disabled using the `tailscale.portDiscovery.enabled` option.
 
 ## How Funnel works
 
@@ -84,13 +84,6 @@ If the extension isn't working, we recommend following these steps to troublesho
 2. Ensure that your Tailnet access controls (ACLs) are [configured to allow Tailscale Funnel](https://tailscale.com/kb/1223/tailscale-funnel/#setup) on your device.
 3. Ensure that [magicDNS and HTTPS Certificates are enabled](https://tailscale.com/kb/1153/enabling-https/) on your tailnet.
 4. If you are running `tailscaled` in a non-default path, you can set its path via the `tailscale.socketPath` setting in VS Code.
-
-## Configuration
-
-- `tailscale.socketPath`: A path to the `tailscaled` unix socket. If unset, the extension will use
-  the default path based on the platform. If set, the extension will use the supplied path.
-
-- `tailscale.portDiscovery`: Whether the extension notifies you of newly opened ports on your machine
 
 ## Contribute
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ You can open the public URL in your default browser or copy it to your clipboard
 
 When you start a local server from VS Code, Tailscale will ask if you'd like to share that port over the internet with Funnel.
 
+You can turn this off in your vscode settings via the `tailscale.portDiscovery` option.
+
 ## How Funnel works
 
 | Internet accessible                                                                                         | Secure tunnel                                                                                                        |
@@ -87,6 +89,8 @@ If the extension isn't working, we recommend following these steps to troublesho
 
 - `tailscale.socketPath`: A path to the `tailscaled` unix socket. If unset, the extension will use
   the default path based on the platform. If set, the extension will use the supplied path.
+
+- `tailscale.portDiscovery`: Whether the extension notifies you of newly opened ports on your machine
 
 ## Contribute
 

--- a/package.json
+++ b/package.json
@@ -198,6 +198,15 @@
               "/var/run/tailscaled.socket",
               "\\\\.\\pipe\\ProtectedPrefix\\Administrators\\Tailscale\\tailscaled"
             ]
+          },
+          "tailscale.portDiscovery": {
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "Whether the extension notifies you of newly opened ports on your machine",
+            "scope": "window",
+            "examples": [
+              false
+            ]
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -199,10 +199,10 @@
               "\\\\.\\pipe\\ProtectedPrefix\\Administrators\\Tailscale\\tailscaled"
             ]
           },
-          "tailscale.portDiscovery": {
+          "tailscale.portDiscovery.enabled": {
             "type": "boolean",
             "default": true,
-            "markdownDescription": "Whether the extension notifies you of newly opened ports on your machine",
+            "markdownDescription": "Enable/disable notification to serve new ports over Tailscale Funnel.",
             "scope": "window",
             "examples": [
               false

--- a/src/tailscale/cli.ts
+++ b/src/tailscale/cli.ts
@@ -44,12 +44,12 @@ export class Tailscale {
     const ts = new Tailscale(vscode);
     await ts.init();
     vscode.workspace.onDidChangeConfiguration((event) => {
-      Logger.info('config changed');
       if (event.affectsConfiguration('tailscale.portDiscovery')) {
         if (ts.portDiscoOn() && !ts.ws) {
-          Logger.info('running port disco');
+          Logger.debug('running port disco');
           ts.runPortDisco();
         } else if (!ts.portDiscoOn() && ts.ws) {
+          Logger.debug('turning off port disco');
           ts.ws.close();
           ts.ws = undefined;
         }

--- a/src/tailscale/cli.ts
+++ b/src/tailscale/cli.ts
@@ -22,6 +22,7 @@ interface vscodeModule {
   window: typeof vscode.window;
   env: typeof vscode.env;
   commands: typeof vscode.commands;
+  workspace: typeof vscode.workspace;
 }
 
 export class Tailscale {
@@ -33,6 +34,7 @@ export class Tailscale {
   private childProcess?: cp.ChildProcess;
   private notifyExit?: () => void;
   private socket?: string;
+  private ws?: WebSocket;
 
   constructor(vscode: vscodeModule) {
     this._vscode = vscode;
@@ -41,6 +43,18 @@ export class Tailscale {
   static async withInit(vscode: vscodeModule): Promise<Tailscale> {
     const ts = new Tailscale(vscode);
     await ts.init();
+    vscode.workspace.onDidChangeConfiguration((event) => {
+      Logger.info('config changed');
+      if (event.affectsConfiguration('tailscale.portDiscovery')) {
+        if (ts.portDiscoOn() && !ts.ws) {
+          Logger.info('running port disco');
+          ts.runPortDisco();
+        } else if (!ts.portDiscoOn() && ts.ws) {
+          ts.ws.close();
+          ts.ws = undefined;
+        }
+      }
+    });
     return ts;
   }
 
@@ -166,6 +180,10 @@ export class Tailscale {
       };
       this.dispose();
     });
+  }
+
+  portDiscoOn() {
+    return vscode.workspace.getConfiguration(EXTENSION_NS).get<boolean>('portDiscovery');
   }
 
   processStderr(childProcess: cp.ChildProcess) {
@@ -306,16 +324,20 @@ export class Tailscale {
     if (!this.url) {
       throw new Error('uninitialized client');
     }
+    if (!this.portDiscoOn()) {
+      Logger.info('port discovery is off');
+      return;
+    }
 
-    const ws = new WebSocket(`ws://${this.url.slice('http://'.length)}/portdisco`, {
+    this.ws = new WebSocket(`ws://${this.url.slice('http://'.length)}/portdisco`, {
       headers: {
         Authorization: 'Basic ' + this.authkey,
       },
     });
-    ws.on('error', (e) => {
+    this.ws.on('error', (e) => {
       Logger.info(`got ws error: ${e}`);
     });
-    ws.on('open', () => {
+    this.ws.on('open', () => {
       Logger.info('websocket is open');
       this._vscode.window.terminals.forEach(async (t) => {
         const pid = await t.processId;
@@ -323,7 +345,7 @@ export class Tailscale {
           return;
         }
         Logger.debug(`adding initial termianl process: ${pid}`);
-        ws.send(
+        this.ws?.send(
           JSON.stringify({
             type: 'addPID',
             pid: pid,
@@ -331,10 +353,10 @@ export class Tailscale {
         );
       });
     });
-    ws.on('close', () => {
+    this.ws.on('close', () => {
       Logger.info('websocket is closed');
     });
-    ws.on('message', async (data) => {
+    this.ws.on('message', async (data) => {
       Logger.info('got message');
       const msg = JSON.parse(data.toString());
       Logger.info(`msg is ${msg.type}`);
@@ -357,7 +379,7 @@ export class Tailscale {
         return;
       }
       Logger.info(`pid is ${pid}`);
-      ws.send(
+      this.ws?.send(
         JSON.stringify({
           type: 'addPID',
           pid: pid,
@@ -370,7 +392,7 @@ export class Tailscale {
       if (!pid) {
         return;
       }
-      ws.send(
+      this.ws?.send(
         JSON.stringify({
           type: 'removePID',
           pid: pid,

--- a/src/tailscale/cli.ts
+++ b/src/tailscale/cli.ts
@@ -44,7 +44,7 @@ export class Tailscale {
     const ts = new Tailscale(vscode);
     await ts.init();
     vscode.workspace.onDidChangeConfiguration((event) => {
-      if (event.affectsConfiguration('tailscale.portDiscovery')) {
+      if (event.affectsConfiguration('tailscale.portDiscovery.enabled')) {
         if (ts.portDiscoOn() && !ts.ws) {
           Logger.debug('running port disco');
           ts.runPortDisco();
@@ -183,7 +183,7 @@ export class Tailscale {
   }
 
   portDiscoOn() {
-    return vscode.workspace.getConfiguration(EXTENSION_NS).get<boolean>('portDiscovery');
+    return vscode.workspace.getConfiguration(EXTENSION_NS).get<boolean>('portDiscovery.enabled');
   }
 
   processStderr(childProcess: cp.ChildProcess) {

--- a/tsrelay/portdisco.go
+++ b/tsrelay/portdisco.go
@@ -44,7 +44,9 @@ func (h *httpHandler) runPortDisco(ctx context.Context, c *websocket.Conn) error
 			err := c.ReadJSON(&msg)
 			if err != nil {
 				// TOOD: handle connection closed
-				h.l.VPrintf("error reading json: %v", err)
+				if !websocket.IsUnexpectedCloseError(err) {
+					h.l.VPrintf("error reading json: %v", err)
+				}
 				return
 			}
 			h.Lock()

--- a/tsrelay/portdisco.go
+++ b/tsrelay/portdisco.go
@@ -33,8 +33,9 @@ type wsMessage struct {
 
 func (h *httpHandler) runPortDisco(ctx context.Context, c *websocket.Conn) error {
 	defer c.Close()
-
+	closeCh := make(chan struct{})
 	go func() {
+		defer close(closeCh)
 		for {
 			if ctx.Err() != nil {
 				return
@@ -43,6 +44,7 @@ func (h *httpHandler) runPortDisco(ctx context.Context, c *websocket.Conn) error
 			err := c.ReadJSON(&msg)
 			if err != nil {
 				// TOOD: handle connection closed
+				h.l.VPrintf("error reading json: %v", err)
 				return
 			}
 			h.Lock()
@@ -86,6 +88,9 @@ func (h *httpHandler) runPortDisco(ctx context.Context, c *websocket.Conn) error
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
+		case <-closeCh:
+			h.l.Println("portdisco reader is closed")
+			return nil
 		case <-ticker.C:
 			ports, changed, err := p.Poll()
 			if err != nil {


### PR DESCRIPTION
This PR allows users to turn on/off port discovery via the vscode settings. This should unblock users who don't want to see much noise, but we can make further enhancements in follow up PRs such as 'snoozing' or a button in the notification to let them know of this option. 

Fixes https://github.com/tailscale-dev/vscode-tailscale/issues/21
Updates https://github.com/tailscale-dev/vscode-tailscale/issues/80