### PR TITLE
File explorer: remove incorrect item for empty dir

### DIFF
--- a/src/ts-file-system-provider.ts
+++ b/src/ts-file-system-provider.ts
@@ -58,9 +58,12 @@ export class TSFileSystemProvider implements vscode.FileSystemProvider {
 
     const s = await this.ssh.runCommandAndPromptForUsername(hostname, 'ls', ['-Ap', resourcePath]);
 
-    const lines = s.trim().split('\n');
+    const lines = s.trim();
     const files: [string, vscode.FileType][] = [];
-    for (const line of lines) {
+    for (const line of lines.split('\n')) {
+      if (line === '') {
+        continue;
+      }
       const isDirectory = line.endsWith('/');
       const type = isDirectory ? vscode.FileType.Directory : vscode.FileType.File;
       const name = isDirectory ? line.slice(0, -1) : line; // Remove trailing slash if it's a directory


### PR DESCRIPTION
We incorrectly add an empty string item for empty directories like the screenshot below:

<img width="336" alt="Screenshot 2023-07-25 at 12 16 50 PM" src="https://github.com/tailscale-dev/vscode-tailscale/assets/16294261/a7c66d4e-0852-473e-9abc-72f8607da390">

This PR skips those lines. 