### PR TITLE
Fix Windows bugs in Node explorer view

### DIFF
--- a/src/node-explorer-provider.ts
+++ b/src/node-explorer-provider.ts
@@ -83,7 +83,13 @@ export class NodeExplorerProvider
         rootDir = '~';
         dirDesc = '~';
       }
-      const uri = vscode.Uri.parse(`ts://${element.TailnetName}/${element.HostName}/${rootDir}`);
+      // This method of building the Uri cleans up the path, removing any
+      // leading or trailing slashes.
+      const uri = vscode.Uri.joinPath(
+        vscode.Uri.from({ scheme: 'ts', authority: element.TailnetName, path: '/' }),
+        element.HostName,
+        ...rootDir.split('/')
+      );
       return [
         new FileExplorer(
           'File explorer',

--- a/src/ts-file-system-provider.ts
+++ b/src/ts-file-system-provider.ts
@@ -1,5 +1,4 @@
 import * as vscode from 'vscode';
-import * as path from 'path';
 import { exec } from 'child_process';
 import { Logger } from './logger';
 import { SSH } from './utils/ssh';
@@ -196,11 +195,14 @@ export class TSFileSystemProvider implements vscode.FileSystemProvider {
   public extractHostAndPath(uri: vscode.Uri): { hostname: string | null; resourcePath: string } {
     switch (uri.scheme) {
       case 'ts': {
-        const hostPath = uri.path.slice(1); // removes leading slash
-
-        const segments = path.normalize(hostPath).split('/');
+        let hostPath = uri.path;
+        if (hostPath.startsWith('/')) {
+          // Remove leading slash
+          hostPath = hostPath.slice(1);
+        }
+        const segments = hostPath.split('/');
         const [hostname, ...pathSegments] = segments;
-        let resourcePath = decodeURIComponent(pathSegments.join(path.sep));
+        let resourcePath = decodeURIComponent(pathSegments.join('/'));
         if (resourcePath !== '~') {
           resourcePath = `/${escapeSpace(resourcePath)}`;
         }


### PR DESCRIPTION
Note: We shouldn't use the `path` node library for parsing URLs. It's for files and is platform specific. We can assume '/'.

Also we should look at the URI we were putting together in getChildren (node-explorer-provider.ts). From what I can tell we would've always had a double leading forward slash.