### PR TITLE
package.json: update context menu items

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,22 +135,22 @@
       ],
       "view/item/context": [
         {
-          "command": "tailscale.node.openRemoteCode",
-          "when": "view == tailscale-node-explorer-view && viewItem == tailscale-peer-item",
-          "group": "1_action@1"
-        },
-        {
-          "command": "tailscale.node.openRemoteCode",
+          "command": "tailscale.node.openTerminal",
           "when": "view == tailscale-node-explorer-view && viewItem == tailscale-peer-item",
           "group": "inline"
         },
         {
           "command": "tailscale.node.openTerminal",
           "when": "view == tailscale-node-explorer-view && viewItem == tailscale-peer-item",
+          "group": "1_action@1"
+        },
+        {
+          "command": "tailscale.node.openRemoteCode",
+          "when": "view == tailscale-node-explorer-view && viewItem == tailscale-peer-item",
           "group": "1_action@2"
         },
         {
-          "command": "tailscale.node.openTerminal",
+          "command": "tailscale.node.openRemoteCode",
           "when": "view == tailscale-node-explorer-view && viewItem == tailscale-peer-item",
           "group": "inline"
         },
@@ -246,7 +246,7 @@
       },
       {
         "command": "tailscale.node.openTerminal",
-        "title": "Open SSH",
+        "title": "Terminal",
         "icon": "$(terminal)"
       },
       {
@@ -256,7 +256,7 @@
       },
       {
         "command": "tailscale.node.openRemoteCode",
-        "title": "Open remote connection",
+        "title": "Attach VS Code",
         "icon": "$(remote-explorer)"
       },
       {
@@ -277,7 +277,7 @@
       },
       {
         "command": "tailscale.node.openRemoteCodeAtLocation",
-        "title": "Open remote connection"
+        "title": "Attach VS Code"
       }
     ],
     "viewsContainers": {


### PR DESCRIPTION
Moved to be more consistent with the Kubernetes extension. It's a hugely popular extension, so I think it's a good idea to follow their lead.

Open SSH => Terminal
Open remote connection => Attach VS Code

Changed order and put Terminal first, since it's likely to be more common and is less disruptive than attaching VS Code.