### PR TITLE
Remove defaultRootPath configuration option

### DIFF
--- a/package.json
+++ b/package.json
@@ -349,16 +349,6 @@
             "examples": [
               "amelie"
             ]
-          },
-          "tailscale.ssh.defaultRootPath": {
-            "type": "string",
-            "default": null,
-            "markdownDescription": "Default root directory for SSH connections.",
-            "scope": "window",
-            "examples": [
-              "/",
-              "home/amelie"
-            ]
           }
         }
       }


### PR DESCRIPTION
We will always default to the home directory, which can still be overwritten per host.