### PR TITLE
Node Explorer: Use the MagicDNS name when appropriate

### DIFF
--- a/src/node-explorer-provider.ts
+++ b/src/node-explorer-provider.ts
@@ -8,6 +8,7 @@ import { Logger } from './logger';
 import { createTsUri, parseTsUri } from './utils/uri';
 import { getUsername } from './utils/host';
 import { FileSystemProvider } from './filesystem-provider';
+import { trimSuffix } from './utils';
 
 export class NodeExplorerProvider implements vscode.TreeDataProvider<PeerBaseTreeItem> {
   dropMimeTypes = ['text/uri-list']; // add 'application/vnd.code.tree.testViewDragAndDrop' when we have file explorer
@@ -108,7 +109,17 @@ export class NodeExplorerProvider implements vscode.TreeDataProvider<PeerBaseTre
           return [];
         }
 
-        this.updateNodeExplorerTailnetName(status.Self.TailnetName);
+        if (
+          status.Self.CurrentTailnet.Name.includes('@') &&
+          status.Self.CurrentTailnet.MagicDNSEnabled &&
+          status.Self.CurrentTailnet.MagicDNSSuffix
+        ) {
+          this.updateNodeExplorerTailnetName(
+            trimSuffix(status.Self.CurrentTailnet.MagicDNSSuffix, '.')
+          );
+        } else {
+          this.updateNodeExplorerTailnetName(status.Self.CurrentTailnet.Name);
+        }
 
         status.Peers?.forEach((p) => {
           this.peers[p.HostName] = p;
@@ -341,7 +352,7 @@ export class PeerTree extends PeerBaseTreeItem {
       ),
     };
 
-    const displayDNSName = this.DNSName.replace(/\.$/, '');
+    const displayDNSName = trimSuffix(this.DNSName, '.');
 
     if (p.Online) {
       this.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;

--- a/src/node-explorer-provider.ts
+++ b/src/node-explorer-provider.ts
@@ -114,9 +114,11 @@ export class NodeExplorerProvider implements vscode.TreeDataProvider<PeerBaseTre
           status.Self.CurrentTailnet.MagicDNSEnabled &&
           status.Self.CurrentTailnet.MagicDNSSuffix
         ) {
-          this.updateNodeExplorerTailnetName(
-            trimSuffix(status.Self.CurrentTailnet.MagicDNSSuffix, '.')
-          );
+          const name = trimSuffix(status.Self.CurrentTailnet.MagicDNSSuffix, '.');
+
+          if (name) {
+            this.updateNodeExplorerTailnetName(name);
+          }
         } else {
           this.updateNodeExplorerTailnetName(status.Self.CurrentTailnet.Name);
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,8 @@ export interface Peer {
 
 interface CurrentTailnet {
   Name: string;
+  MagicDNSEnabled: boolean;
+  MagicDNSSuffix?: string;
 }
 
 export interface Status extends WithErrors {
@@ -70,7 +72,7 @@ export interface RelayError {
 interface PeerStatus {
   DNSName: string;
   Online: boolean;
-  TailnetName: string;
+  CurrentTailnet: CurrentTailnet;
 }
 
 export interface ServeConfig {

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -1,8 +1,4 @@
-export function trimSuffix(str: string | undefined, suffix: string) {
-  if (!str) {
-    return;
-  }
-
+export function trimSuffix(str: string, suffix: string): string {
   return str.endsWith(suffix) ? str.slice(0, -suffix.length) : str;
 }
 

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -1,4 +1,8 @@
-export function trimSuffix(str: string, suffix: string): string {
+export function trimSuffix(str: string | undefined, suffix: string) {
+  if (!str) {
+    return;
+  }
+
   return str.endsWith(suffix) ? str.slice(0, -suffix.length) : str;
 }
 

--- a/tsrelay/handler/get_serve.go
+++ b/tsrelay/handler/get_serve.go
@@ -34,15 +34,22 @@ type serveStatus struct {
 	Errors       []Error `json:",omitempty"`
 }
 
+type currentTailnet struct {
+	Name            string
+	MagicDNSSuffix  string
+	MagicDNSEnabled bool
+}
+
 type peerStatus struct {
 	DNSName string
 	Online  bool
 
 	// For node explorer
-	ID           tailcfg.StableNodeID
-	HostName     string
-	TailscaleIPs []netip.Addr
-	TailnetName  string
+	ID             tailcfg.StableNodeID
+	HostName       string
+	TailscaleIPs   []netip.Addr
+	TailnetName    string
+	CurrentTailnet currentTailnet
 }
 
 // TODO(marwan): since this endpoint serves both the Node Explorer and Funnel,
@@ -170,7 +177,11 @@ func (h *handler) getServe(ctx context.Context, body io.Reader, withPeers bool) 
 			ID:           st.Self.ID,
 			HostName:     st.Self.HostName,
 			TailscaleIPs: st.Self.TailscaleIPs,
-			TailnetName:  st.CurrentTailnet.Name,
+			CurrentTailnet: currentTailnet{
+				Name:            st.CurrentTailnet.Name,
+				MagicDNSSuffix:  st.CurrentTailnet.MagicDNSSuffix,
+				MagicDNSEnabled: st.CurrentTailnet.MagicDNSEnabled,
+			},
 		}
 		capabilities := st.Self.Capabilities
 		if slices.Contains(capabilities, tailcfg.CapabilityWarnFunnelNoInvite) ||


### PR DESCRIPTION
If the MagicDNS is enabled, and the tailnet name is an email address (includes an @), use the MagicDNSName

![image](https://github.com/tailscale-dev/vscode-tailscale/assets/40265/de5d89d3-aace-4102-bbd8-d4bfbec46165)
