### PR TITLE
Node Explorer: Include full DNSName for external nodes

### DIFF
--- a/src/node-explorer-provider.ts
+++ b/src/node-explorer-provider.ts
@@ -8,6 +8,7 @@ import { Logger } from './logger';
 import { createTsUri, parseTsUri } from './utils/uri';
 import { getUsername } from './utils/host';
 import { FileSystemProvider } from './filesystem-provider';
+import { trimSuffix } from './utils';
 
 export class NodeExplorerProvider implements vscode.TreeDataProvider<PeerBaseTreeItem> {
   dropMimeTypes = ['text/uri-list']; // add 'application/vnd.code.tree.testViewDragAndDrop' when we have file explorer
@@ -108,7 +109,17 @@ export class NodeExplorerProvider implements vscode.TreeDataProvider<PeerBaseTre
           return [];
         }
 
-        this.updateNodeExplorerTailnetName(status.Self.TailnetName);
+        if (
+          status.Self.CurrentTailnet.Name.includes('@') &&
+          status.Self.CurrentTailnet.MagicDNSEnabled &&
+          status.Self.CurrentTailnet.MagicDNSSuffix
+        ) {
+          this.updateNodeExplorerTailnetName(
+            trimSuffix(status.Self.CurrentTailnet.MagicDNSSuffix, '.')
+          );
+        } else {
+          this.updateNodeExplorerTailnetName(status.Self.CurrentTailnet.Name);
+        }
 
         status.Peers?.forEach((p) => {
           this.peers[p.HostName] = p;
@@ -341,7 +352,7 @@ export class PeerTree extends PeerBaseTreeItem {
       ),
     };
 
-    const displayDNSName = this.DNSName.replace(/\.$/, '');
+    const displayDNSName = trimSuffix(this.DNSName, '.');
 
     if (p.Online) {
       this.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;

--- a/src/node-explorer-provider.ts
+++ b/src/node-explorer-provider.ts
@@ -109,16 +109,18 @@ export class NodeExplorerProvider implements vscode.TreeDataProvider<PeerBaseTre
           return [];
         }
 
-        let tailnetName = status.Self.CurrentTailnet.Name;
+        let tailnetName = status.CurrentTailnet.Name;
 
         // If the MagicDNS is enabled, and the tailnet name is an
-        // email address (includes an @), use the MagicDNSName
+        // email address (includes an @), use the MagicDNSName as
+        // it makes more sense to show the MagicDNS name for multi-user
+        // tailnets using a shared domain.
         if (
-          status.Self.CurrentTailnet.Name.includes('@') &&
-          status.Self.CurrentTailnet.MagicDNSEnabled &&
-          status.Self.CurrentTailnet.MagicDNSSuffix
+          status.CurrentTailnet.Name.includes('@') &&
+          status.CurrentTailnet.MagicDNSEnabled &&
+          status.CurrentTailnet.MagicDNSSuffix
         ) {
-          const name = trimSuffix(status.Self.CurrentTailnet.MagicDNSSuffix, '.');
+          const name = trimSuffix(status.CurrentTailnet.MagicDNSSuffix, '.');
 
           if (name) {
             tailnetName = name;
@@ -327,6 +329,7 @@ export class PeerTree extends PeerBaseTreeItem {
   public ID: string;
   public HostName: string;
   public TailscaleIPs: string[];
+  public TailnetName: string;
   public DNSName: string;
 
   public constructor(p: Peer) {
@@ -335,9 +338,12 @@ export class PeerTree extends PeerBaseTreeItem {
     this.ID = p.ID;
     this.HostName = p.HostName;
     this.TailscaleIPs = p.TailscaleIPs;
+    this.TailnetName = p.TailnetName;
     this.DNSName = p.DNSName;
 
     if (p.IsExternal) {
+      // localapi currently does not return the tailnet name for a node,
+      // so this is what we have to do to determine it.
       const re = new RegExp('^' + p.ServerName + '\\.');
       this.description = trimSuffix(this.DNSName.replace(re, ''), '.');
     }

--- a/src/node-explorer-provider.ts
+++ b/src/node-explorer-provider.ts
@@ -321,17 +321,20 @@ export class PeerTree extends PeerBaseTreeItem {
   public ID: string;
   public HostName: string;
   public TailscaleIPs: string[];
-  public TailnetName: string;
   public DNSName: string;
 
   public constructor(p: Peer) {
-    super(p.HostName);
+    super(p.ServerName);
 
     this.ID = p.ID;
     this.HostName = p.HostName;
     this.TailscaleIPs = p.TailscaleIPs;
-    this.TailnetName = p.TailnetName;
     this.DNSName = p.DNSName;
+
+    if (p.IsExternal) {
+      const re = new RegExp('^' + p.ServerName + '\\.');
+      this.description = trimSuffix(this.DNSName.replace(re, ''), '.');
+    }
 
     this.iconPath = {
       light: path.join(

--- a/src/node-explorer-provider.ts
+++ b/src/node-explorer-provider.ts
@@ -109,6 +109,8 @@ export class NodeExplorerProvider implements vscode.TreeDataProvider<PeerBaseTre
           return [];
         }
 
+        // If the MagicDNS is enabled, and the tailnet name is an
+        // email address (includes an @), use the MagicDNSName
         if (
           status.Self.CurrentTailnet.Name.includes('@') &&
           status.Self.CurrentTailnet.MagicDNSEnabled &&

--- a/src/node-explorer-provider.ts
+++ b/src/node-explorer-provider.ts
@@ -109,6 +109,8 @@ export class NodeExplorerProvider implements vscode.TreeDataProvider<PeerBaseTre
           return [];
         }
 
+        let tailnetName = status.Self.CurrentTailnet.Name;
+
         // If the MagicDNS is enabled, and the tailnet name is an
         // email address (includes an @), use the MagicDNSName
         if (
@@ -116,12 +118,14 @@ export class NodeExplorerProvider implements vscode.TreeDataProvider<PeerBaseTre
           status.Self.CurrentTailnet.MagicDNSEnabled &&
           status.Self.CurrentTailnet.MagicDNSSuffix
         ) {
-          this.updateNodeExplorerTailnetName(
-            trimSuffix(status.Self.CurrentTailnet.MagicDNSSuffix, '.')
-          );
-        } else {
-          this.updateNodeExplorerTailnetName(status.Self.CurrentTailnet.Name);
+          const name = trimSuffix(status.Self.CurrentTailnet.MagicDNSSuffix, '.');
+
+          if (name) {
+            tailnetName = name;
+          }
         }
+
+        this.updateNodeExplorerTailnetName(tailnetName);
 
         status.Peers?.forEach((p) => {
           this.peers[p.HostName] = p;

--- a/src/node-explorer-provider.ts
+++ b/src/node-explorer-provider.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import * as vscode from 'vscode';
 import * as path from 'path';
-import { Peer } from './types';
+import { CurrentTailnet, Peer } from './types';
 import { Tailscale } from './tailscale/cli';
 import { ConfigManager } from './config-manager';
 import { Logger } from './logger';
@@ -83,7 +83,7 @@ export class NodeExplorerProvider implements vscode.TreeDataProvider<PeerBaseTre
       }
 
       const uri = createTsUri({
-        tailnet: element.TailnetName,
+        tailnet: element.CurrentTailnet.Name,
         hostname: element.HostName,
         resourcePath: rootDir,
       });
@@ -131,7 +131,7 @@ export class NodeExplorerProvider implements vscode.TreeDataProvider<PeerBaseTre
 
         status.Peers?.forEach((p) => {
           this.peers[p.HostName] = p;
-          peers.push(new PeerTree({ ...p }));
+          peers.push(new PeerTree({ ...p }, status.CurrentTailnet));
         });
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } catch (e: any) {
@@ -329,17 +329,17 @@ export class PeerTree extends PeerBaseTreeItem {
   public ID: string;
   public HostName: string;
   public TailscaleIPs: string[];
-  public TailnetName: string;
   public DNSName: string;
+  public CurrentTailnet: CurrentTailnet;
 
-  public constructor(p: Peer) {
+  public constructor(p: Peer, currentTailnet: CurrentTailnet) {
     super(p.ServerName);
 
     this.ID = p.ID;
     this.HostName = p.HostName;
     this.TailscaleIPs = p.TailscaleIPs;
-    this.TailnetName = p.TailnetName;
     this.DNSName = p.DNSName;
+    this.CurrentTailnet = currentTailnet;
 
     if (p.IsExternal) {
       // localapi currently does not return the tailnet name for a node,

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,8 @@ export interface Peer {
 
 interface CurrentTailnet {
   Name: string;
+  MagicDNSEnabled: boolean;
+  MagicDNSSuffix?: string;
 }
 
 export interface Status extends WithErrors {
@@ -70,7 +72,7 @@ export interface RelayError {
 interface PeerStatus {
   DNSName: string;
   Online: boolean;
-  TailnetName: string;
+  CurrentTailnet: CurrentTailnet;
 }
 
 export interface ServeConfig {

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,6 +52,8 @@ export interface ServeStatus extends WithErrors {
     [port: number]: string;
   };
   BackendState: string;
+  // TODO: Self is optional in the API, which might not be
+  // correct. We need to settle on it being optional or always present.
   Self: PeerStatus;
   Peers?: Peer[];
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,17 +29,17 @@ export interface Peer {
   TailscaleIPs: string[];
   sshHostKeys?: string[];
   ShareeNode?: boolean;
+  TailnetName: string;
   DNSName: string;
 }
 
-interface CurrentTailnet {
+export interface CurrentTailnet {
   Name: string;
   MagicDNSEnabled: boolean;
   MagicDNSSuffix?: string;
 }
 
 export interface Status extends WithErrors {
-  CurrentTailnet: CurrentTailnet;
   Peer: {
     [key: string]: Peer;
   };
@@ -56,6 +56,7 @@ export interface ServeStatus extends WithErrors {
   // correct. We need to settle on it being optional or always present.
   Self: PeerStatus;
   Peers?: Peer[];
+  CurrentTailnet: CurrentTailnet;
 }
 
 export interface WithErrors {
@@ -75,7 +76,7 @@ export interface RelayError {
 interface PeerStatus {
   DNSName: string;
   Online: boolean;
-  CurrentTailnet: CurrentTailnet;
+  TailnetName: string;
 }
 
 export interface ServeConfig {

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,7 +29,6 @@ export interface Peer {
   TailscaleIPs: string[];
   sshHostKeys?: string[];
   ShareeNode?: boolean;
-  TailnetName: string;
   DNSName: string;
 }
 
@@ -76,7 +75,6 @@ export interface RelayError {
 interface PeerStatus {
   DNSName: string;
   Online: boolean;
-  TailnetName: string;
 }
 
 export interface ServeConfig {

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,13 +21,14 @@ export interface Handlers {
 
 export interface Peer {
   ID: string;
+  ServerName: string;
   HostName: string;
   Active?: boolean;
+  IsExternal: boolean;
   Online?: boolean;
   TailscaleIPs: string[];
   sshHostKeys?: string[];
   ShareeNode?: boolean;
-  TailnetName: string;
   DNSName: string;
 }
 

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -1,8 +1,4 @@
-export function trimSuffix(str: string | undefined, suffix: string) {
-  if (!str) {
-    return;
-  }
-
+export function trimSuffix(str: string, suffix: string): string {
   return str.endsWith(suffix) ? str.slice(0, -suffix.length) : str;
 }
 

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -1,4 +1,8 @@
-export function trimSuffix(str: string, suffix: string): string {
+export function trimSuffix(str: string | undefined, suffix: string) {
+  if (!str) {
+    return;
+  }
+
   return str.endsWith(suffix) ? str.slice(0, -suffix.length) : str;
 }
 

--- a/tsrelay/handler/get_serve.go
+++ b/tsrelay/handler/get_serve.go
@@ -50,7 +50,6 @@ type peerStatus struct {
 	ID           tailcfg.StableNodeID
 	HostName     string
 	TailscaleIPs []netip.Addr
-	TailnetName  string
 	IsExternal   bool
 }
 
@@ -150,7 +149,6 @@ func (h *handler) getServe(ctx context.Context, body io.Reader, withPeers bool) 
 			ID:           p.ID,
 			HostName:     p.HostName,
 			TailscaleIPs: p.TailscaleIPs,
-			TailnetName:  st.CurrentTailnet.Name,
 			IsExternal:   isExternal,
 		})
 	}
@@ -197,7 +195,6 @@ func (h *handler) getServe(ctx context.Context, body io.Reader, withPeers bool) 
 			ID:           st.Self.ID,
 			HostName:     st.Self.HostName,
 			TailscaleIPs: st.Self.TailscaleIPs,
-			TailnetName:  st.CurrentTailnet.Name,
 		}
 
 		s.CurrentTailnet = &currentTailnet{

--- a/tsrelay/handler/get_serve.go
+++ b/tsrelay/handler/get_serve.go
@@ -135,11 +135,17 @@ func (h *handler) getServe(ctx context.Context, body io.Reader, withPeers bool) 
 		ServerName := p.HostName
 		if p.DNSName != "" {
 			parts := strings.SplitN(p.DNSName, ".", 2)
-			ServerName = parts[0]
+			if len(parts) > 0 {
+				ServerName = parts[0]
+			}
 		}
 
-		DNSNameNoRootLabel := strings.TrimSuffix(p.DNSName, ".")
-		IsExternal := !strings.HasSuffix(DNSNameNoRootLabel, st.CurrentTailnet.MagicDNSSuffix)
+		// removes the root label/trailing period from the DNSName
+		// before: "amalie.foo.ts.net.", after: "amalie.foo.ts.net"
+		dnsNameNoRootLabel := strings.TrimSuffix(p.DNSName, ".")
+
+		// if the DNSName does not end with the magic DNS suffix, it is an external peer
+		isExternal := !strings.HasSuffix(dnsNameNoRootLabel, st.CurrentTailnet.MagicDNSSuffix)
 
 		s.Peers = append(s.Peers, &peerStatus{
 			DNSName:      p.DNSName,
@@ -148,7 +154,7 @@ func (h *handler) getServe(ctx context.Context, body io.Reader, withPeers bool) 
 			ID:           p.ID,
 			HostName:     p.HostName,
 			TailscaleIPs: p.TailscaleIPs,
-			IsExternal:   IsExternal,
+			IsExternal:   isExternal,
 		})
 	}
 

--- a/tsrelay/handler/get_serve.go
+++ b/tsrelay/handler/get_serve.go
@@ -34,15 +34,22 @@ type serveStatus struct {
 	Errors       []Error `json:",omitempty"`
 }
 
+type currentTailnet struct {
+	Name            string
+	MagicDNSSuffix  string
+	MagicDNSEnabled bool
+}
+
 type peerStatus struct {
 	DNSName string
 	Online  bool
 
 	// For node explorer
-	ID           tailcfg.StableNodeID
-	HostName     string
-	TailscaleIPs []netip.Addr
-	TailnetName  string
+	ID             tailcfg.StableNodeID
+	HostName       string
+	TailscaleIPs   []netip.Addr
+	TailnetName    string
+	CurrentTailnet currentTailnet
 }
 
 // TODO(marwan): since this endpoint serves both the Node Explorer and Funnel,
@@ -170,7 +177,11 @@ func (h *handler) getServe(ctx context.Context, body io.Reader, withPeers bool) 
 			ID:           st.Self.ID,
 			HostName:     st.Self.HostName,
 			TailscaleIPs: st.Self.TailscaleIPs,
-			TailnetName:  st.CurrentTailnet.Name,
+			CurrentTailnet: currentTailnet{
+				Name:            st.CurrentTailnet.Name,
+				MagicDNSSuffix:  st.CurrentTailnet.MagicDNSSuffix,
+				MagicDNSEnabled: st.CurrentTailnet.MagicDNSEnabled,
+			},
 		}
 		capabilities := st.Self.Capabilities
 		if slices.Contains(capabilities, tailcfg.CapabilityWarnFunnelNoInvite) ||


### PR DESCRIPTION
Nodes that are external to a user's Tailnet, or "Shared In" should be identified by having the rest of the DNS name set as a description.

Additionally, we are displaying the name according to the DNS entry, not the OS's hostname.

Closes ENG-1919
Stacked on https://github.com/tailscale-dev/vscode-tailscale/pull/147

![image](https://github.com/tailscale-dev/vscode-tailscale/assets/40265/47f7fe0c-e3e7-4741-a4a7-f9b960ddce94)
