### PR TITLE
Fix empty peer list with link to adding node

### DIFF
--- a/package.json
+++ b/package.json
@@ -282,6 +282,10 @@
       {
         "command": "tailscale.node.openRemoteCodeAtLocation",
         "title": "Attach VS Code"
+      },
+      {
+        "command": "tailscale.openExternal",
+        "title": "Open External Link"
       }
     ],
     "viewsContainers": {

--- a/src/node-explorer-provider.ts
+++ b/src/node-explorer-provider.ts
@@ -378,11 +378,13 @@ export class PeerDetailTreeItem extends PeerBaseTreeItem {
 export class NoPeersItem extends vscode.TreeItem {
   constructor(label: string) {
     super(label);
+    this.iconPath = new vscode.ThemeIcon('link-external');
     this.command = {
       command: 'tailscale.openExternal',
       title: 'Add node',
       arguments: ['https://tailscale.com/kb/1017/install/'],
     };
+    this.tooltip = 'Open Link';
   }
 }
 


### PR DESCRIPTION
This PR ensures that if a user has no peers _and_ it's not an error from the backend, then we prompt them to add their first peer. 

<img width="474" alt="Screenshot 2023-08-02 at 9 17 07 AM" src="https://github.com/tailscale-dev/vscode-tailscale/assets/16294261/9ff51180-a031-4464-aac7-8acfe364b1db">

Fixes ENG-1922