### PR TITLE
Distinguish between display name and tailnet name

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -79,7 +79,7 @@ export async function activate(context: vscode.ExtensionContext) {
   // eslint-disable-next-line prefer-const
   let nodeExplorerView: vscode.TreeView<PeerTree | FileExplorer | NoPeersItem>;
 
-  function updateNodeExplorerTailnetName(name: string) {
+  function updateNodeExplorerDisplayName(name: string) {
     nodeExplorerView.title = name;
   }
 
@@ -95,7 +95,7 @@ export async function activate(context: vscode.ExtensionContext) {
     tailscaleInstance,
     configManager,
     fileSystemProvider,
-    updateNodeExplorerTailnetName
+    updateNodeExplorerDisplayName
   );
 
   nodeExplorerView = createNodeExplorerView();


### PR DESCRIPTION
The name at the top is not always tailnet name, so let's call it dipslayName. 
Also PeerTree doesn't need the entire object, just the name. 