### PR TITLE
Rename view and viewItem contexts for consistency with tree classes

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,84 +115,84 @@
         {
           "command": "tailscale.refreshServe",
           "group": "overflow",
-          "when": "view == tailscale-serve-view"
+          "when": "view == serve-view"
         },
         {
           "command": "tailscale.resetServe",
           "group": "overflow",
-          "when": "view == tailscale-serve-view"
+          "when": "view == serve-view"
         },
         {
           "command": "tailscale.openAdminConsole",
           "group": "overflow",
-          "when": "view == tailscale-serve-view || view == tailscale-node-explorer-view"
+          "when": "view == serve-view || view == node-explorer-view"
         },
         {
           "command": "tailscale.nodeExplorer.refresh",
           "group": "navigation",
-          "when": "view == tailscale-node-explorer-view"
+          "when": "view == node-explorer-view"
         }
       ],
       "view/item/context": [
         {
           "command": "tailscale.node.openTerminal",
-          "when": "view == tailscale-node-explorer-view && viewItem == tailscale-peer-item",
+          "when": "view == node-explorer-view && viewItem == peer-root",
           "group": "inline"
         },
         {
           "command": "tailscale.node.openTerminal",
-          "when": "view == tailscale-node-explorer-view && viewItem == tailscale-peer-item",
+          "when": "view == node-explorer-view && viewItem == peer-root",
           "group": "1_action@1"
         },
         {
           "command": "tailscale.node.openRemoteCode",
-          "when": "view == tailscale-node-explorer-view && viewItem == tailscale-peer-item",
+          "when": "view == node-explorer-view && viewItem == peer-root",
           "group": "1_action@2"
         },
         {
           "command": "tailscale.node.openRemoteCode",
-          "when": "view == tailscale-node-explorer-view && viewItem == tailscale-peer-item",
+          "when": "view == node-explorer-view && viewItem == peer-root",
           "group": "inline"
         },
         {
           "command": "tailscale.node.setUsername",
-          "when": "view == tailscale-node-explorer-view && viewItem == tailscale-peer-item",
+          "when": "view == node-explorer-view && viewItem == peer-root",
           "group": "2_settings@3"
         },
         {
           "command": "tailscale.node.setRootDir",
-          "when": "(view == tailscale-node-explorer-view && viewItem == tailscale-peer-item) || (view == tailscale-node-explorer-view && viewItem =~ /^file-explorer-item-root/)",
+          "when": "(view == node-explorer-view && viewItem == peer-root) || (view == node-explorer-view && viewItem =~ /^peer-file-explorer-root/)",
           "group": "2_settings@3"
         },
         {
           "command": "tailscale.node.copyIPv4",
-          "when": "view == tailscale-node-explorer-view && viewItem == tailscale-peer-item",
+          "when": "view == node-explorer-view && viewItem == peer-root",
           "group": "3_copy@1"
         },
         {
           "command": "tailscale.node.copyIPv6",
-          "when": "view == tailscale-node-explorer-view && viewItem == tailscale-peer-item",
+          "when": "view == node-explorer-view && viewItem == peer-root",
           "group": "3_copy@1"
         },
         {
           "command": "tailscale.node.copyHostname",
-          "when": "view == tailscale-node-explorer-view && viewItem == tailscale-peer-item",
+          "when": "view == node-explorer-view && viewItem == peer-root",
           "group": "3_copy@1"
         },
         {
           "command": "tailscale.node.openDetailsLink",
           "group": "4_control@1",
-          "when": "view == tailscale-node-explorer-view && viewItem == tailscale-peer-item"
+          "when": "view == node-explorer-view && viewItem == peer-root"
         },
         {
           "command": "tailscale.node.openRemoteCodeAtLocation",
           "group": "1_action@2",
-          "when": "view == tailscale-node-explorer-view && viewItem =~ /^file-explorer-item-root/"
+          "when": "view == node-explorer-view && viewItem =~ /^peer-file-explorer-root/"
         },
         {
           "command": "tailscale.node.fs.delete",
-          "group": "2_fileAction@2",
-          "when": "view == tailscale-node-explorer-view && viewItem =~ /^file-explorer-item-child/"
+          "group": "4_fileAction@1",
+          "when": "view == node-explorer-view && viewItem =~ /^peer-file-explorer-child/"
         }
       ]
     },
@@ -307,14 +307,14 @@
     "views": {
       "tailscale-serve-panel": [
         {
-          "id": "tailscale-serve-view",
+          "id": "serve-view",
           "name": "Funnel",
           "type": "webview"
         }
       ],
       "tailscale-nodes-explorer": [
         {
-          "id": "tailscale-node-explorer-view",
+          "id": "node-explorer-view",
           "name": "",
           "when": "config.tailscale.nodeExplorer.enabled"
         }

--- a/resources/walkthrough/share-port.md
+++ b/resources/walkthrough/share-port.md
@@ -2,4 +2,4 @@
 
 You're all set! Let's share a port with Tailscale Funnel to get started.
 
-You can do this from the [Funnel UI](command:tailscale-serve-view.focus) or using [Tailscale: Share port publicly using Funnel](command:tailscale.sharePortOverTunnel) from the command palette.
+You can do this from the [Funnel UI](command:serve-view.focus) or using [Tailscale: Share port publicly using Funnel](command:tailscale.sharePortOverTunnel) from the command palette.

--- a/src/tailscale/cli.ts
+++ b/src/tailscale/cli.ts
@@ -438,6 +438,6 @@ export class Tailscale {
       this._vscode.env.clipboard.writeText(`https://${hostname}`);
     }
 
-    await this._vscode.commands.executeCommand('tailscale-serve-view.refresh');
+    await this._vscode.commands.executeCommand('serve-view.refresh');
   }
 }


### PR DESCRIPTION
I was finding it difficult to remember the hierarchy of the TreeView, as the naming has not been consistent over time. This attempts to create a naming convention for the TreeItem classes and their contextValue.

I also removed "tailscale-" from the view ID's as they need only be unique within our extension and the larger names made the when clauses more unruly.