### PR TITLE
File Explorer: Add inline context for refresh

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,6 +170,11 @@
           "group": "3_copy@1"
         },
         {
+          "command": "tailscale.nodeExplorer.refresh",
+          "group": "inline",
+          "when": "view == node-explorer-view && viewItem =~ /^peer-file-explorer-root/"
+        },
+        {
           "command": "tailscale.node.copyIPv6",
           "when": "view == node-explorer-view && viewItem == peer-root",
           "group": "3_copy@1"

--- a/src/node-explorer-provider.ts
+++ b/src/node-explorer-provider.ts
@@ -20,8 +20,9 @@ export class NodeExplorerProvider implements vscode.TreeDataProvider<PeerBaseTre
   dropMimeTypes = ['text/uri-list']; // add 'application/vnd.code.tree.testViewDragAndDrop' when we have file explorer
   dragMimeTypes = [];
 
-  private _onDidChangeTreeData: vscode.EventEmitter<(PeerBaseTreeItem | undefined)[] | undefined> =
-    new vscode.EventEmitter<PeerBaseTreeItem[] | undefined>();
+  private _onDidChangeTreeData: vscode.EventEmitter<
+    (PeerBaseTreeItem | FileExplorer | undefined)[] | undefined
+  > = new vscode.EventEmitter<PeerBaseTreeItem[] | undefined>();
 
   // We want to use an array as the event type, but the API for this is currently being finalized. Until it's finalized, use any.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -302,9 +303,12 @@ export class NodeExplorerProvider implements vscode.TreeDataProvider<PeerBaseTre
   }
 
   registerRefresh(): void {
-    vscode.commands.registerCommand('tailscale.nodeExplorer.refresh', () => {
-      this._onDidChangeTreeData.fire(undefined);
-    });
+    vscode.commands.registerCommand(
+      'tailscale.nodeExplorer.refresh',
+      (f: FileExplorer | undefined) => {
+        this._onDidChangeTreeData.fire([f]);
+      }
+    );
   }
 
   openRemoteCodeWindow(host: string, reuseWindow: boolean) {


### PR DESCRIPTION
Allows for an easy way to retry the file explorer connection.

![image](https://github.com/tailscale-dev/vscode-tailscale/assets/40265/a37dd0ed-187b-4d00-bde9-af78d0be4169)
