### PR TITLE
Update node tooltips to standardize "is online" / "is offline"

### DIFF
--- a/src/node-explorer-provider.ts
+++ b/src/node-explorer-provider.ts
@@ -426,7 +426,7 @@ export class PeerTree extends PeerBaseTreeItem {
 
     if (p.Online) {
       this.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
-      this.tooltip = displayDNSName;
+      this.tooltip = `${displayDNSName} is online`;
     } else {
       this.tooltip = `${displayDNSName} is offline`;
     }


### PR DESCRIPTION
When you hover over a node name, if it's online, it just says the node name. If it's offline, it says "$node-name is offline"

This adds "is online" so that the tooltip is consistent between offline/online states.

Fixes ENG-1959

![image](https://github.com/tailscale-dev/vscode-tailscale/assets/3967272/a29da355-4389-4f31-998d-3f0dfe329d53)

---------

Signed-off-by: Sam Linville <sam@tailscale.com>
