### PR TITLE
Use Address instead of Hostname to connect

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -136,15 +136,15 @@ export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand('tailscale.node.setUsername', async (node: PeerRoot) => {
       const username = await vscode.window.showInputBox({
-        prompt: `Enter the username to use for ${node.HostName}`,
-        value: configManager.config?.hosts?.[node.HostName]?.user,
+        prompt: `Enter the username to use for ${node.ServerName}`,
+        value: configManager.config?.hosts?.[node.Address]?.user,
       });
 
       if (!username) {
         return;
       }
 
-      configManager.setForHost(node.HostName, 'user', username);
+      configManager.setForHost(node.Address, 'user', username);
     })
   );
 
@@ -152,19 +152,19 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand(
       'tailscale.node.setRootDir',
       async (node: PeerRoot | FileExplorer | ErrorItem) => {
-        let hostname: string;
+        let address: string;
 
         if (node instanceof FileExplorer) {
-          hostname = parseTsUri(node.uri).hostname;
+          address = parseTsUri(node.uri).address;
         } else if (node instanceof PeerRoot) {
-          hostname = node.HostName;
+          address = node.Address;
         } else {
           throw new Error(`invalid node type: ${typeof node}`);
         }
 
         const dir = await vscode.window.showInputBox({
-          prompt: `Enter the root directory to use for ${hostname}`,
-          value: configManager.config?.hosts?.[hostname]?.rootDir || '~',
+          prompt: `Enter the root directory to use for ${address}`,
+          value: configManager.config?.hosts?.[address]?.rootDir || '~',
         });
 
         if (!dir) {
@@ -176,7 +176,7 @@ export async function activate(context: vscode.ExtensionContext) {
           return;
         }
 
-        configManager.setForHost(hostname, 'rootDir', dir);
+        configManager.setForHost(address, 'rootDir', dir);
         nodeExplorerProvider.refreshAll();
       }
     )

--- a/src/filesystem-provider-sftp.ts
+++ b/src/filesystem-provider-sftp.ts
@@ -74,22 +74,22 @@ export class FileSystemProviderSFTP implements vscode.FileSystemProvider {
 
   async rename(): Promise<void> {}
 
-  async getHomeDirectory(hostname: string): Promise<string> {
-    const sftp = await this.manager.getSftp(hostname);
+  async getHomeDirectory(address: string): Promise<string> {
+    const sftp = await this.manager.getSftp(address);
     if (!sftp) throw new Error('Failed to establish SFTP connection');
 
     return await sftp.getHomeDirectory();
   }
 
   async getParsedUriAndSftp(uri: vscode.Uri) {
-    const { hostname, resourcePath } = parseTsUri(uri);
-    const sftp = await this.manager.getSftp(hostname);
+    const { address, resourcePath } = parseTsUri(uri);
+    const sftp = await this.manager.getSftp(address);
 
     if (!sftp) {
       throw new Error('Unable to establish SFTP connection');
     }
 
-    return { hostname, resourcePath, sftp };
+    return { address, resourcePath, sftp };
   }
 }
 

--- a/src/node-explorer-provider.ts
+++ b/src/node-explorer-provider.ts
@@ -82,10 +82,10 @@ export class NodeExplorerProvider implements vscode.TreeDataProvider<PeerBaseTre
         ];
       }
       const { hosts } = this.configManager?.config || {};
-      let rootDir = hosts?.[element.HostName]?.rootDir;
+      let rootDir = hosts?.[element.Address]?.rootDir;
       let dirDesc = rootDir;
       try {
-        const homeDir = await this.fsProvider.getHomeDirectory(element.HostName);
+        const homeDir = await this.fsProvider.getHomeDirectory(element.Address);
 
         if (rootDir && rootDir !== '~') {
           dirDesc = trimPathPrefix(rootDir, homeDir);
@@ -102,7 +102,7 @@ export class NodeExplorerProvider implements vscode.TreeDataProvider<PeerBaseTre
 
       const uri = createTsUri({
         tailnet: element.tailnetName,
-        hostname: element.HostName,
+        address: element.Address,
         resourcePath: rootDir,
       });
 
@@ -203,8 +203,8 @@ export class NodeExplorerProvider implements vscode.TreeDataProvider<PeerBaseTre
     vscode.commands.registerCommand(
       'tailscale.node.fs.createDirectory',
       async (node: FileExplorer) => {
-        const { hostname, tailnet, resourcePath } = parseTsUri(node.uri);
-        if (!hostname || !resourcePath) {
+        const { address, tailnet, resourcePath } = parseTsUri(node.uri);
+        if (!address || !resourcePath) {
           return;
         }
 
@@ -220,7 +220,7 @@ export class NodeExplorerProvider implements vscode.TreeDataProvider<PeerBaseTre
 
         const newUri = createTsUri({
           tailnet,
-          hostname,
+          address,
           resourcePath: `${resourcePath}/${dirName}`,
         });
 
@@ -238,7 +238,7 @@ export class NodeExplorerProvider implements vscode.TreeDataProvider<PeerBaseTre
     vscode.commands.registerCommand(
       'tailscale.node.openRemoteCodeAtLocation',
       async (file: FileExplorer) => {
-        const { hostname, resourcePath } = parseTsUri(file.uri);
+        const { address: hostname, resourcePath } = parseTsUri(file.uri);
         if (!hostname || !resourcePath) {
           return;
         }
@@ -281,15 +281,15 @@ export class NodeExplorerProvider implements vscode.TreeDataProvider<PeerBaseTre
 
   registerOpenTerminalCommand() {
     vscode.commands.registerCommand('tailscale.node.openTerminal', async (node: PeerRoot) => {
-      const t = vscode.window.createTerminal(node.HostName);
-      t.sendText(`ssh ${getUsername(this.configManager, node.HostName)}@${node.HostName}`);
+      const t = vscode.window.createTerminal(node.Address);
+      t.sendText(`ssh ${getUsername(this.configManager, node.Address)}@${node.Address}`);
       t.show();
     });
   }
 
   registerOpenRemoteCodeCommand() {
     vscode.commands.registerCommand('tailscale.node.openRemoteCode', async (node: PeerRoot) => {
-      this.openRemoteCodeWindow(node.HostName, false);
+      this.openRemoteCodeWindow(node.Address, false);
     });
   }
 
@@ -391,11 +391,15 @@ export class PeerRoot extends PeerBaseTreeItem {
   public DNSName: string;
   public SSHEnabled: boolean;
   public tailnetName: string;
+  public Address: string;
+  public ServerName: string;
 
   public constructor(p: Peer, tailnetName: string) {
     super(p.ServerName);
 
     this.ID = p.ID;
+    this.ServerName = p.ServerName;
+    this.Address = p.Address;
     this.HostName = p.HostName;
     this.TailscaleIPs = p.TailscaleIPs;
     this.DNSName = p.DNSName;

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,7 @@ export interface Peer {
   ShareeNode?: boolean;
   DNSName: string;
   SSHEnabled: boolean;
+  Address: string;
 }
 
 export interface CurrentTailnet {

--- a/src/utils/uri.test.ts
+++ b/src/utils/uri.test.ts
@@ -16,7 +16,7 @@ describe('parseTsUri', () => {
   test('parses ts URIs correctly', () => {
     const testUri = URI.parse('ts://tails-scales/foo/home/amalie');
     const expected = {
-      hostname: 'foo',
+      address: 'foo',
       tailnet: 'tails-scales',
       resourcePath: '/home/amalie',
     };
@@ -34,7 +34,7 @@ describe('parseTsUri', () => {
   test('correctly returns ~ as a resourcePath', () => {
     const testUri = URI.parse('ts://tails-scales/foo/~');
     const expected = {
-      hostname: 'foo',
+      address: 'foo',
       tailnet: 'tails-scales',
       resourcePath: '.',
     };
@@ -46,7 +46,7 @@ describe('parseTsUri', () => {
   test('correctly returns ~ in a deeply nested resourcePath', () => {
     const testUri = URI.parse('ts://tails-scales/foo/~/bar/baz');
     const expected = {
-      hostname: 'foo',
+      address: 'foo',
       tailnet: 'tails-scales',
       resourcePath: './bar/baz',
     };
@@ -60,7 +60,7 @@ describe('createTsUri', () => {
   test('creates ts URIs correctly', () => {
     const expected = URI.parse('ts://tails-scales/foo/home/amalie');
     const params = {
-      hostname: 'foo',
+      address: 'foo',
       tailnet: 'tails-scales',
       resourcePath: '/home/amalie',
     };
@@ -71,7 +71,7 @@ describe('createTsUri', () => {
   test('creates ts URIs correctly', () => {
     const expected = URI.parse('ts://tails-scales/foo/~');
     const params = {
-      hostname: 'foo',
+      address: 'foo',
       tailnet: 'tails-scales',
       resourcePath: '~',
     };

--- a/src/utils/uri.ts
+++ b/src/utils/uri.ts
@@ -2,7 +2,7 @@ import { Uri } from 'vscode';
 import { escapeSpace } from './string';
 
 export interface TsUri {
-  hostname: string;
+  address: string;
   tailnet: string;
   resourcePath: string;
 }
@@ -25,7 +25,7 @@ export function parseTsUri(uri: Uri): TsUri {
       }
 
       const segments = hostPath.split('/');
-      const [hostname, ...pathSegments] = segments;
+      const [address, ...pathSegments] = segments;
 
       if (pathSegments[0] === '~') {
         pathSegments[0] = '.';
@@ -37,7 +37,7 @@ export function parseTsUri(uri: Uri): TsUri {
         resourcePath = `/${escapeSpace(resourcePath)}`;
       }
 
-      return { hostname, tailnet: uri.authority, resourcePath };
+      return { address, tailnet: uri.authority, resourcePath };
     }
     default:
       throw new Error(`Unsupported scheme: ${uri.scheme}`);
@@ -46,14 +46,14 @@ export function parseTsUri(uri: Uri): TsUri {
 
 interface TsUriParams {
   tailnet: string;
-  hostname: string;
+  address: string;
   resourcePath: string;
 }
 
-export function createTsUri({ tailnet, hostname, resourcePath }: TsUriParams): Uri {
+export function createTsUri({ tailnet, address, resourcePath }: TsUriParams): Uri {
   return Uri.joinPath(
     Uri.from({ scheme: 'ts', authority: tailnet, path: '/' }),
-    hostname,
+    address,
     ...resourcePath.split('/')
   );
 }

--- a/tsrelay/handler/get_peers.go
+++ b/tsrelay/handler/get_peers.go
@@ -105,6 +105,10 @@ func (h *handler) getPeers(ctx context.Context, body io.Reader) (*getPeersRespon
 		// if the DNSName does not end with the magic DNS suffix, it is an external peer
 		isExternal := !strings.HasSuffix(dnsNameNoRootLabel, st.CurrentTailnet.MagicDNSSuffix)
 
+		addr := p.DNSName
+		if addr == "" && len(p.TailscaleIPs) > 0 {
+			addr = p.TailscaleIPs[0].String()
+		}
 		s.Peers = append(s.Peers, &peerStatus{
 			DNSName:      p.DNSName,
 			ServerName:   serverName,
@@ -114,6 +118,7 @@ func (h *handler) getPeers(ctx context.Context, body io.Reader) (*getPeersRespon
 			TailscaleIPs: p.TailscaleIPs,
 			IsExternal:   isExternal,
 			SSHEnabled:   len(p.SSH_HostKeys) > 0,
+			Address:      addr,
 		})
 	}
 

--- a/tsrelay/handler/get_serve.go
+++ b/tsrelay/handler/get_serve.go
@@ -43,6 +43,11 @@ type peerStatus struct {
 	TailscaleIPs []netip.Addr
 	IsExternal   bool
 	SSHEnabled   bool
+
+	// The address you can use to connect/ssh. Either DNSName or IPv4.
+	// You can connect in various ways but some are not stable. For example
+	// HostName works unless you change your machine's name.
+	Address string
 }
 
 func (h *handler) getServeHandler(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Use full DNSName (or fallback to IPv4) when connecting to different nodes in explorer. 

Fixes ENG-1970