### PR TITLE
File Explorer: Fix issue with creating directory from file

### DIFF
--- a/src/node-explorer-provider.ts
+++ b/src/node-explorer-provider.ts
@@ -245,7 +245,7 @@ export class NodeExplorerProvider implements vscode.TreeDataProvider<PeerBaseTre
 
       const newName = await vscode.window.showInputBox({
         prompt: 'Enter a new name for the file',
-        value: path.basename(source.path),
+        value: source.path.split('/').pop() || '',
       });
 
       if (!newName) {
@@ -272,25 +272,34 @@ export class NodeExplorerProvider implements vscode.TreeDataProvider<PeerBaseTre
           return;
         }
 
+        let targetPath = resourcePath;
+
         // TODO: validate input
-        const dirName = await vscode.window.showInputBox({
+        const targetName = await vscode.window.showInputBox({
           prompt: 'Enter a name for the new directory',
           placeHolder: 'New directory',
         });
 
-        if (!dirName) {
+        if (!targetName) {
           return;
+        }
+
+        if (node.type !== vscode.FileType.Directory) {
+          const lastSlashIndex = resourcePath.lastIndexOf('/');
+          targetPath = resourcePath.substring(0, lastSlashIndex);
         }
 
         const newUri = createTsUri({
           tailnet,
           address,
-          resourcePath: `${resourcePath}/${dirName}`,
+          resourcePath: `${targetPath}/${targetName}`,
         });
 
         try {
           await vscode.workspace.fs.createDirectory(newUri);
-          this._onDidChangeTreeData.fire([node]);
+          this._onDidChangeTreeData.fire([
+            node.type !== vscode.FileType.Directory ? undefined : node,
+          ]);
         } catch (e) {
           vscode.window.showErrorMessage(`Could not create directory: ${e}`);
         }


### PR DESCRIPTION
When creating a directory using the context from a file, we should use its parent. We can also no longer trigger a rebuild on the provided node.