### PR TITLE
File Explorer: Limit create actions to directories

### DIFF
--- a/package.json
+++ b/package.json
@@ -197,22 +197,22 @@
         {
           "command": "tailscale.node.fs.createDirectory",
           "group": "3_dirAction@1",
-          "when": "view == node-explorer-view && viewItem =~ /^peer-file-explorer/"
+          "when": "view == node-explorer-view && viewItem =~ /^peer-file-explorer-dir/"
         },
         {
           "command": "tailscale.node.fs.createFile",
           "group": "3_dirAction@2",
-          "when": "view == node-explorer-view && viewItem =~ /^peer-file-explorer-child/"
+          "when": "view == node-explorer-view && viewItem =~ /^peer-file-explorer-dir/"
         },
         {
           "command": "tailscale.node.fs.rename",
           "group": "4_fileAction@1",
-          "when": "view == node-explorer-view && viewItem =~ /^peer-file-explorer-child/"
+          "when": "view == node-explorer-view && viewItem =~ /^peer-file-explorer-(dir|file)/"
         },
         {
           "command": "tailscale.node.fs.delete",
           "group": "4_fileAction@2",
-          "when": "view == node-explorer-view && viewItem =~ /^peer-file-explorer-child/"
+          "when": "view == node-explorer-view && viewItem =~ /^peer-file-explorer-(dir|file)/"
         }
       ]
     },

--- a/src/node-explorer-provider.ts
+++ b/src/node-explorer-provider.ts
@@ -75,7 +75,7 @@ export class NodeExplorerProvider implements vscode.TreeDataProvider<PeerBaseTre
       const dirents = await vscode.workspace.fs.readDirectory(element.uri);
       return dirents.map(([name, type]) => {
         const childUri = element.uri.with({ path: `${element.uri.path}/${name}` });
-        return new FileExplorer(name, childUri, type, 'child');
+        return new FileExplorer(name, childUri, type);
       });
     }
 
@@ -468,7 +468,9 @@ export class FileExplorer extends vscode.TreeItem {
       };
     }
 
-    this.contextValue = `peer-file-explorer${context && `-${context}`}`;
+    const typeDesc = type === vscode.FileType.File ? 'file' : 'dir';
+
+    this.contextValue = `peer-file-explorer-${typeDesc}${context && `-${context}`}`;
   }
 }
 


### PR DESCRIPTION
This limits the create file and directory actions to a context on a directory.