### PR TITLE
Node Explorer: Some error message improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -208,6 +208,11 @@
           "command": "tailscale.node.fs.delete",
           "group": "4_fileAction@2",
           "when": "view == node-explorer-view && viewItem =~ /^peer-file-explorer-(dir|file)/"
+        },
+        {
+          "command": "tailscale.node.openDocsLink",
+          "group": "inline",
+          "when": "view == node-explorer-view && viewItem =~ /^peer-error-link/"
         }
       ]
     },
@@ -309,6 +314,11 @@
       {
         "command": "tailscale.openExternal",
         "title": "Open External Link"
+      },
+      {
+        "command": "tailscale.node.openDocsLink",
+        "title": "Open Documentation",
+        "icon": "$(link-external)"
       }
     ],
     "viewsContainers": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,7 +6,12 @@ import { ADMIN_CONSOLE } from './utils/url';
 import { Tailscale } from './tailscale';
 import { Logger } from './logger';
 import { errorForType } from './tailscale/error';
-import { FileExplorer, NodeExplorerProvider, PeerRoot, ErrorItem } from './node-explorer-provider';
+import {
+  FileExplorer,
+  NodeExplorerProvider,
+  PeerRoot,
+  PeerErrorItem,
+} from './node-explorer-provider';
 
 import { FileSystemProviderSFTP } from './filesystem-provider-sftp';
 import { ConfigManager } from './config-manager';
@@ -65,13 +70,13 @@ export async function activate(context: vscode.ExtensionContext) {
   );
 
   // eslint-disable-next-line prefer-const
-  let nodeExplorerView: vscode.TreeView<PeerRoot | FileExplorer | ErrorItem>;
+  let nodeExplorerView: vscode.TreeView<PeerRoot | FileExplorer | PeerErrorItem>;
 
   function updateNodeExplorerDisplayName(name: string) {
     nodeExplorerView.title = name;
   }
 
-  const createNodeExplorerView = (): vscode.TreeView<PeerRoot | FileExplorer | ErrorItem> => {
+  const createNodeExplorerView = (): vscode.TreeView<PeerRoot | FileExplorer | PeerErrorItem> => {
     return vscode.window.createTreeView('node-explorer-view', {
       treeDataProvider: nodeExplorerProvider,
       showCollapseAll: true,
@@ -89,13 +94,6 @@ export async function activate(context: vscode.ExtensionContext) {
   nodeExplorerView = createNodeExplorerView();
   vscode.window.registerTreeDataProvider('node-explorer-view', nodeExplorerProvider);
   context.subscriptions.push(nodeExplorerView);
-
-  context.subscriptions.push(
-    vscode.commands.registerCommand('tailscale.openExternal', (url: string) => {
-      Logger.info('called tailscale.openExternal', 'command');
-      vscode.env.openExternal(vscode.Uri.parse(url));
-    })
-  );
 
   context.subscriptions.push(
     vscode.commands.registerCommand('tailscale.refreshServe', () => {
@@ -144,7 +142,7 @@ export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand(
       'tailscale.node.setRootDir',
-      async (node: PeerRoot | FileExplorer | ErrorItem) => {
+      async (node: PeerRoot | FileExplorer | PeerErrorItem) => {
         let address: string;
 
         if (node instanceof FileExplorer) {


### PR DESCRIPTION
Using a Tree View Item as a button to trigger a command, which we are doing, is explicitly [called out](https://code.visualstudio.com/api/ux-guidelines/views#tree-views) as a "Don't" in the UX Guidelines.

To adhere to this, we should use an inline context for the external docs link.

On hover, you see the following:

**Tailscale not running:**

![image](https://github.com/tailscale-dev/vscode-tailscale/assets/40265/2a674311-7a92-4c8d-b161-59cad9552b49)

**Running but not logged in:**

![image](https://github.com/tailscale-dev/vscode-tailscale/assets/40265/7fc8b67c-4c4d-43fe-920f-f5e12246813a)
