### PR TITLE
File Explorer: Use ServerName in path

### DIFF
--- a/src/node-explorer-provider.ts
+++ b/src/node-explorer-provider.ts
@@ -112,7 +112,7 @@ export class NodeExplorerProvider implements vscode.TreeDataProvider<PeerBaseTre
 
       const uri = createTsUri({
         tailnet: element.tailnetName,
-        address: element.Address,
+        address: element.ServerName,
         resourcePath: rootDir,
       });
 

--- a/src/utils/uri.ts
+++ b/src/utils/uri.ts
@@ -11,7 +11,7 @@ export interface TsUri {
  *
  * ts://tails-scales/foo/home/amalie
  * |> tailnet: tails-scales
- * |> hostname: foo
+ * |> address: foo
  * |> resourcePath: /home/amalie
  */
 


### PR DESCRIPTION
Since we are already using the tailnet name in the Uri, we don't need to include the fully qualified domain name in the path.

`ts://tylersmalley@gmail.com/haas.alpine-banded.ts.net/home/pi/hello` becomes `ts://tylersmalley@gmail.com/haas/home/pi/hello`