### PR TITLE
Re-enable drag and drop

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,6 +135,11 @@
       ],
       "view/item/context": [
         {
+          "command": "tailscale.node.downloadRemoteFile",
+          "when": "view == node-explorer-view && viewItem =~ /^peer-file-explorer-file/",
+          "group": "inline"
+        },
+        {
           "command": "tailscale.node.openTerminal",
           "when": "view == node-explorer-view && (viewItem =~ /^peer-file-explorer-dir/ || viewItem == peer-root)",
           "group": "inline"
@@ -278,6 +283,11 @@
         "command": "tailscale.node.openRemoteCode",
         "title": "Attach VS Code",
         "icon": "$(remote-explorer)"
+      },
+      {
+        "command": "tailscale.node.downloadRemoteFile",
+        "title": "Download to your workspace",
+        "icon": "$(cloud-download)"
       },
       {
         "command": "tailscale.node.openDetailsLink",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -91,8 +91,8 @@ export async function activate(context: vscode.ExtensionContext) {
     updateNodeExplorerDisplayName
   );
 
-  nodeExplorerView = createNodeExplorerView();
   vscode.window.registerTreeDataProvider('node-explorer-view', nodeExplorerProvider);
+  nodeExplorerView = createNodeExplorerView();
   context.subscriptions.push(nodeExplorerView);
 
   context.subscriptions.push(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -168,7 +168,7 @@ export async function activate(context: vscode.ExtensionContext) {
         }
 
         configManager.setForHost(address, 'rootDir', dir);
-        nodeExplorerProvider.refreshAll();
+        nodeExplorerProvider.refresh();
       }
     )
   );

--- a/src/filesystem-provider-sftp.ts
+++ b/src/filesystem-provider-sftp.ts
@@ -97,6 +97,15 @@ export class FileSystemProviderSFTP implements vscode.FileSystemProvider {
     return await sftp.rename(sourcePath, targetPath);
   });
 
+  upload = withFileSystemErrorHandling('upload', async (source: vscode.Uri, target: vscode.Uri) => {
+    const sourcePath = source.path;
+    const { resourcePath: targetPath, sftp } = await this.getParsedUriAndSftp(target);
+
+    Logger.info(`Uploading ${sourcePath} to ${targetPath}`, 'tsFs-sftp');
+
+    return await sftp.uploadFile(sourcePath, targetPath);
+  });
+
   async getHomeDirectory(address: string): Promise<string> {
     const sftp = await this.manager.getSftp(address);
     if (!sftp) throw new Error('Failed to establish SFTP connection');

--- a/src/filesystem-provider-timing.ts
+++ b/src/filesystem-provider-timing.ts
@@ -75,12 +75,20 @@ export class WithFSTiming implements FileSystemProvider {
   async rename(
     oldUri: vscode.Uri,
     newUri: vscode.Uri,
-    options: { readonly overwrite: boolean }
+    options: { readonly overwrite: boolean } = { overwrite: false }
   ): Promise<void> {
     const startTime = new Date().getTime();
     const res = await this.fsp.rename(oldUri, newUri, options);
     const endTime = new Date().getTime();
     Logger.info(`${endTime - startTime}ms for rename`, `tsFs-timing`);
+    return res;
+  }
+
+  async upload(source: vscode.Uri, target: vscode.Uri): Promise<void> {
+    const startTime = new Date().getTime();
+    const res = await this.fsp.upload(source, target);
+    const endTime = new Date().getTime();
+    Logger.info(`${endTime - startTime}ms for upload`, `tsFs-timing`);
     return res;
   }
 

--- a/src/filesystem-provider.ts
+++ b/src/filesystem-provider.ts
@@ -4,6 +4,7 @@ import * as vscode from 'vscode';
 // implementations grab the home directory differently
 export interface FileSystemProvider extends vscode.FileSystemProvider {
   getHomeDirectory(hostname: string): Promise<string>;
+  upload(source: vscode.Uri, target: vscode.Uri): Promise<void>;
 }
 
 // fileSorter mimicks the Node Explorer file structure in that directories

--- a/src/node-explorer-provider.ts
+++ b/src/node-explorer-provider.ts
@@ -301,8 +301,7 @@ export class NodeExplorerProvider
               }
               const fileContent = await vscode.workspace.fs.readFile(file.uri);
               const fileName = path.basename(file.uri.toString());
-              const targetPath =
-                vscode.workspace.workspaceFolders?.at(0)?.uri.path + '/' + fileName;
+              const targetPath = workspacePath + '/' + fileName;
               const localPath = vscode.Uri.file(targetPath);
               await vscode.workspace.fs.writeFile(localPath, fileContent);
             } catch (e) {

--- a/src/sftp.ts
+++ b/src/sftp.ts
@@ -77,6 +77,12 @@ export class Sftp {
     return util.promisify(sftp.rmdir).call(sftp, path);
   }
 
+  async uploadFile(localPath: string, remotePath: string): Promise<void> {
+    console.log('uploadFile', localPath, remotePath);
+    const sftp = await this.getSftp();
+    return util.promisify(sftp.fastPut).call(sftp, localPath, remotePath);
+  }
+
   convertFileType(stats: ssh2.Stats): vscode.FileType {
     if (stats.isDirectory()) {
       return vscode.FileType.Directory;

--- a/src/ssh.ts
+++ b/src/ssh.ts
@@ -13,7 +13,7 @@ export class SSH {
     options?: { stdin?: string; sudoPassword?: string }
   ): Promise<string> {
     return new Promise((resolve, reject) => {
-      const sshArgs = [];
+      const sshArgs: string[] = [];
 
       if (options?.sudoPassword) {
         sshArgs.push('sudo', '-S', command, ...args);


### PR DESCRIPTION
This PR re-enables drag and drop to use the new ssh2 library. SInce we don't show you your local machine in the node explorer, added a downloaded option to get remote files into your workspace

Fixes ENG-1933