### PR TITLE
Node Explorer: Always remove root label from DNSName

### DIFF
--- a/tsrelay/handler/get_peers.go
+++ b/tsrelay/handler/get_peers.go
@@ -120,7 +120,7 @@ func (h *handler) getPeers(ctx context.Context, body io.Reader) (*getPeersRespon
 			addr = p.TailscaleIPs[0].String()
 		}
 		peer := &peerStatus{
-			DNSName:      p.DNSName,
+			DNSName:      dnsNameNoRootLabel,
 			ServerName:   serverName,
 			Online:       p.Online,
 			ID:           p.ID,


### PR DESCRIPTION
Including the root label in the DNSName for display purposes, outside the context of DNS zone files is not ideal.