### PR TITLE
package.json: support "workspace" extension kind

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "*"
   ],
   "extensionKind": [
-    "ui"
+    "ui",
+    "workspace"
   ],
   "main": "./dist/extension.js",
   "contributes": {


### PR DESCRIPTION
This allows extensions to be activated in the context of a "workspace"
which enables the extension to work the web-based VS Code server, ala
code-server.