### PR TITLE
tsrelay/handler: add offline peer group

### DIFF
--- a/tsrelay/handler/get_peers.go
+++ b/tsrelay/handler/get_peers.go
@@ -73,6 +73,7 @@ func (h *handler) getPeers(ctx context.Context, body io.Reader) (*getPeersRespon
 		PeerGroups: []*peerGroup{
 			{Name: "My nodes"},
 			{Name: "All nodes"},
+			{Name: "Offline nodes"},
 		},
 	}
 
@@ -130,7 +131,10 @@ func (h *handler) getPeers(ctx context.Context, body io.Reader) (*getPeersRespon
 			SSHEnabled:   len(p.SSH_HostKeys) > 0,
 			Address:      addr,
 		}
-		if p.UserID == st.Self.UserID {
+
+		if !p.Online {
+			s.PeerGroups[2].Peers = append(s.PeerGroups[2].Peers, peer)
+		} else if p.UserID == st.Self.UserID {
 			s.PeerGroups[0].Peers = append(s.PeerGroups[0].Peers, peer)
 		} else {
 			s.PeerGroups[1].Peers = append(s.PeerGroups[1].Peers, peer)
@@ -150,12 +154,6 @@ func (h *handler) getPeers(ctx context.Context, body io.Reader) (*getPeersRespon
 	for _, pg := range s.PeerGroups {
 		peers := pg.Peers
 		sort.Slice(peers, func(i, j int) bool {
-			if peers[i].Online && !peers[j].Online {
-				return true
-			}
-			if peers[j].Online && !peers[i].Online {
-				return false
-			}
 			return peers[i].HostName < peers[j].HostName
 		})
 	}

--- a/tsrelay/handler/get_peers.go
+++ b/tsrelay/handler/get_peers.go
@@ -69,12 +69,11 @@ func (h *handler) getPeers(ctx context.Context, body io.Reader) (*getPeersRespon
 		return nil, err
 	}
 
-	s := getPeersResponse{
-		PeerGroups: []*peerGroup{
-			{Name: "My nodes"},
-			{Name: "All nodes"},
-			{Name: "Offline nodes"},
-		},
+	s := getPeersResponse{PeerGroups: []*peerGroup{}}
+	peerGroups := [...]*peerGroup{
+		{Name: "My nodes"},
+		{Name: "All nodes"},
+		{Name: "Offline nodes"},
 	}
 
 	if st.BackendState == "NeedsLogin" || (st.Self != nil && !st.Self.Online) {
@@ -133,28 +132,24 @@ func (h *handler) getPeers(ctx context.Context, body io.Reader) (*getPeersRespon
 		}
 
 		if !p.Online {
-			s.PeerGroups[2].Peers = append(s.PeerGroups[2].Peers, peer)
+			peerGroups[2].Peers = append(peerGroups[2].Peers, peer)
 		} else if p.UserID == st.Self.UserID {
-			s.PeerGroups[0].Peers = append(s.PeerGroups[0].Peers, peer)
+			peerGroups[0].Peers = append(peerGroups[0].Peers, peer)
 		} else {
-			s.PeerGroups[1].Peers = append(s.PeerGroups[1].Peers, peer)
+			peerGroups[1].Peers = append(peerGroups[1].Peers, peer)
 		}
 	}
 
-	myNodes := len(s.PeerGroups[0].Peers)
-	allNodes := len(s.PeerGroups[1].Peers)
-	if myNodes == 0 && allNodes > 0 {
-		s.PeerGroups = s.PeerGroups[1:]
-	} else if allNodes == 0 && myNodes > 0 {
-		s.PeerGroups = s.PeerGroups[0:1]
-	} else if myNodes == 0 && allNodes == 0 {
-		s.PeerGroups = nil
+	for _, pg := range peerGroups {
+		if len(pg.Peers) > 0 {
+			s.PeerGroups = append(s.PeerGroups, pg)
+		}
 	}
 
 	for _, pg := range s.PeerGroups {
 		peers := pg.Peers
 		sort.Slice(peers, func(i, j int) bool {
-			return peers[i].HostName < peers[j].HostName
+			return peers[i].ServerName < peers[j].ServerName
 		})
 	}
 


### PR DESCRIPTION
Put offline peers in a separate group. This improves the UI when there are a lot of peers, and makes it easier to see and reach for the online peers in "All nodes".

Fixes: #185