### PR TITLE
Machine Explorer: Exclude DNS root label from address

### DIFF
--- a/tsrelay/handler/get_peers.go
+++ b/tsrelay/handler/get_peers.go
@@ -115,7 +115,7 @@ func (h *handler) getPeers(ctx context.Context, body io.Reader) (*getPeersRespon
 		// if the DNSName does not end with the magic DNS suffix, it is an external peer
 		isExternal := !strings.HasSuffix(dnsNameNoRootLabel, st.CurrentTailnet.MagicDNSSuffix)
 
-		addr := p.DNSName
+		addr := dnsNameNoRootLabel
 		if addr == "" && len(p.TailscaleIPs) > 0 {
 			addr = p.TailscaleIPs[0].String()
 		}


### PR DESCRIPTION
The trailing period (root label) was removed from the DNS name in (#181), but should have also been removed from the label which is derived from the DNS name.