### PR TITLE
tasks: Use tool/yarn

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,8 +4,9 @@
   "version": "2.0.0",
   "tasks": [
     {
-      "type": "npm",
-      "script": "watch",
+      "type": "shell",
+      "label": "watch",
+      "command": "./tool/yarn run watch",
       "problemMatcher": "$ts-webpack-watch",
       "isBackground": true,
       "presentation": {
@@ -18,8 +19,9 @@
       }
     },
     {
-      "type": "npm",
-      "script": "watch-tests",
+      "type": "shell",
+      "label": "watch-tests",
+      "command": "./tool/yarn run watch-tests",
       "problemMatcher": "$tsc-watch",
       "isBackground": true,
       "presentation": {


### PR DESCRIPTION
VS Code tasks should use tool/yarn, and not the system-wide yarn.