### PR TITLE
Node Explorer: accept subdirectories of ~ for root directory

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -168,7 +168,7 @@ export async function activate(context: vscode.ExtensionContext) {
           return;
         }
 
-        if (!path.isAbsolute(dir) && dir !== '~') {
+        if (!path.isAbsolute(dir) && dir !== '~' && !dir.startsWith('~/')) {
           vscode.window.showErrorMessage(`${dir} is an invalid absolute path`);
           return;
         }

--- a/src/node-explorer-provider.ts
+++ b/src/node-explorer-provider.ts
@@ -96,6 +96,9 @@ export class NodeExplorerProvider
         const homeDir = await this.fsProvider.getHomeDirectory(element.Address);
 
         if (rootDir && rootDir !== '~') {
+          if (rootDir.startsWith('~/')) {
+            rootDir = `${homeDir}/${rootDir.slice(2)}`;
+          }
           dirDesc = trimPathPrefix(rootDir, homeDir);
         } else {
           rootDir = homeDir;


### PR DESCRIPTION
Fixes #200.