### PR TITLE
Support for a trace log level

### DIFF
--- a/src/tailscale/cli.ts
+++ b/src/tailscale/cli.ts
@@ -60,7 +60,7 @@ export class Tailscale {
 
   defaultArgs() {
     const args = [];
-    if (this._vscode.env.logLevel === LogLevel.Debug) {
+    if (this._vscode.env.logLevel >= LogLevel.Debug) {
       args.push('-v');
     }
     if (this.port) {
@@ -362,7 +362,7 @@ export class Tailscale {
         if (!pid) {
           return;
         }
-        Logger.debug(`adding initial termianl process: ${pid}`);
+        Logger.debug(`adding initial terminal process: ${pid}`);
         this.ws?.send(
           JSON.stringify({
             type: 'addPID',


### PR DESCRIPTION
I had set my log level to trace in VS Code, but was not seeing the verbose logs for relay. 