### PR TITLE
changelog: v0.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Allow setting a sub-directory as a root using tilde (example: ~/foo)
 - Add "tailscale.fileExplorer.showDotFiles" to control if dot-files (example: .foo) are shown in the File Explorer.
 - Support for Tailscale client version 1.50.0
+- Auto-refresh Node Explorer periodically for updates to your tailnet. The polling period can be configured (and polling can be disabled) via "tailscale.nodeExplorer.refreshInterval".
 
 ## v0.6.2 - August 23, 2023
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to an [Odd-Even Versioning](https://en.wikipedia.org/wiki/Software_versioning#Odd-numbered_versions_for_development_releases) scheme. Odd-numbered versions are used for development and pre-release updates, while even-numbered versions are used for stable or public releases.
 
+## v0.6.3 - September 27, 2023
+
+- Using "Attach VS Code" requires the user to be defined in the SSH configuration. We will now prompt to sync SSH configuration when using that feature.
+- Allow setting a sub-directory as a root using tilde (example: ~/foo)
+- Add "tailscale.fileExplorer.showDotFiles" to control if dot-files (example: .foo) are shown in the File Explorer.
+- Support for Tailscale client version 1.50.0
+
 ## v0.6.2 - August 23, 2023
 
 - Allow for opening and editing of symlinks


### PR DESCRIPTION
```
% git log --pretty=oneline v0.6.2..release-branch/v0.6
(HEAD -> release-branch/v0.6) chore(deps): update dependency @vscode/vsce to ^2.21.0 (#223)
chore(deps): update dependency @types/vscode-webview to ^1.57.2 (#218)
chore(deps): update dependency concurrently to ^8.2.1 (#219)
chore(deps): update dependency lint-staged to ^13.3.0 (#196)
tsrelay: update for 1.50 (#239)
Node Explorer: prompt to add nodes to SSH config file for VSCode remotes list (#233)
Node Explorer: accept subdirectories of ~ for root directory (#230)
File Explorer: add configuration option to hide dotfiles (#221)
package.json: Remove from testing category (#226)
chore(deps): update dependency swr to ^2.2.2 (#195)
chore(deps): update dependency @types/react to ^18.2.21 (#194)
chore(deps): update eslint (#137)
package.json: Updates the description (#215)
README.md: Use lowercase "internet" (#216)
```