### PR TITLE
changelog: change release version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to an [Odd-Even Versioning](https://en.wikipedia.org/wiki/Software_versioning#Odd-numbered_versions_for_development_releases) scheme. Odd-numbered versions are used for development and pre-release updates, while even-numbered versions are used for stable or public releases.
 
-## v0.6.3 - September 27, 2023
+## v0.6.4 - September 27, 2023
 
 - Using "Attach VS Code" requires the user to be defined in the SSH configuration. We will now prompt to sync SSH configuration when using that feature.
 - Allow setting a sub-directory as a root using tilde (example: ~/foo)


### PR DESCRIPTION
I missed the changelog backport for v0.6.3, so re-releasing as v0.6.4