### PR TITLE
Node Explorer: follow symbolic links to directories

### DIFF
--- a/src/filesystem-provider.ts
+++ b/src/filesystem-provider.ts
@@ -10,10 +10,10 @@ export interface FileSystemProvider extends vscode.FileSystemProvider {
 // fileSorter mimicks the Node Explorer file structure in that directories
 // are displayed first in alphabetical followed by files in the same fashion.
 export function fileSorter(a: [string, vscode.FileType], b: [string, vscode.FileType]): number {
-  if (a[1] === vscode.FileType.Directory && b[1] !== vscode.FileType.Directory) {
+  if (a[1] & vscode.FileType.Directory && !(b[1] & vscode.FileType.Directory)) {
     return -1;
   }
-  if (a[1] !== vscode.FileType.Directory && b[1] === vscode.FileType.Directory) {
+  if (!(a[1] & vscode.FileType.Directory) && b[1] & vscode.FileType.Directory) {
     return 1;
   }
 

--- a/src/node-explorer-provider.ts
+++ b/src/node-explorer-provider.ts
@@ -514,13 +514,13 @@ export class NodeExplorerProvider
   registerDeleteCommand() {
     vscode.commands.registerCommand('tailscale.node.fs.delete', async (file: FileExplorer) => {
       try {
-        const fileType =
-          file.type & vscode.FileType.SymbolicLink
-            ? 'symbolic link'
-            : file.type & vscode.FileType.Directory
-            ? 'directory'
-            : 'file';
-        const msg = `Are you sure you want to delete this ${fileType}? This action cannot be undone.`;
+        let fileDescription = 'file';
+        if (file.type & vscode.FileType.SymbolicLink) {
+          fileDescription = 'symbolic link';
+        } else if (file.type & vscode.FileType.Directory) {
+          fileDescription = 'directory';
+        }
+        const msg = `Are you sure you want to delete this ${fileDescription}? This action cannot be undone.`;
 
         const answer = await vscode.window.showInformationMessage(msg, { modal: true }, 'Yes');
 

--- a/src/sftp.ts
+++ b/src/sftp.ts
@@ -19,9 +19,9 @@ export class Sftp {
     let result = await util.promisify(sftp.readlink).call(sftp, linkPath);
 
     // if link is relative, not absolute
-    // TODO(naman): how does path.join behave with Windows? Do absolute URIs start with /?
     if (!result.startsWith('/')) {
-      result = path.join(path.dirname(linkPath), result);
+      // note: this needs to be / even on Windows, so don't use path.join()
+      result = `${path.dirname(linkPath)}/${result}`;
     }
 
     return result;

--- a/src/sftp.ts
+++ b/src/sftp.ts
@@ -1,3 +1,4 @@
+import path = require('path');
 import * as ssh2 from 'ssh2';
 import * as util from 'util';
 import * as vscode from 'vscode';
@@ -13,15 +14,14 @@ export class Sftp {
     return this.sftpPromise;
   }
 
-  async readSymbolicLink(path: string): Promise<string> {
+  async readSymbolicLink(linkPath: string): Promise<string> {
     const sftp = await this.getSftp();
-    let result = await util.promisify(sftp.readlink).call(sftp, path);
+    let result = await util.promisify(sftp.readlink).call(sftp, linkPath);
 
     // if link is relative, not absolute
+    // TODO(naman): how does path.join behave with Windows? Do absolute URIs start with /?
     if (!result.startsWith('/')) {
-      // split path by separator, slice away the last bit to get the parent directory,
-      // append the relative path, and join it back together
-      result = [...path.split('/').slice(0, -1), result].join('/');
+      result = path.join(path.dirname(linkPath), result);
     }
 
     return result;

--- a/src/sftp.ts
+++ b/src/sftp.ts
@@ -1,4 +1,4 @@
-import path = require('path');
+import * as path from 'path';
 import * as ssh2 from 'ssh2';
 import * as util from 'util';
 import * as vscode from 'vscode';


### PR DESCRIPTION
Fixes #209.

The biggest change in this PR is that we'll be treating `vscode.FileType` as a bitfield now, rather than just checking for equality, since the SFTP file provider is modified to return symlinks as `SymbolicLink | File` or `SymbolicLink | Directory` rather than just `SymbolicLink`.

Also, should wait for @shayne (or someone else) to confirm that SFTP to a Windows host still uses `/` as the path separator before merging (unfortunately I don't have a Windows machine to test).