### PR TITLE
File Explorer: Fix issue with spaces in filenames

### DIFF
--- a/src/filesystem-provider-ssh.ts
+++ b/src/filesystem-provider-ssh.ts
@@ -3,7 +3,6 @@ import { exec } from 'child_process';
 import { Logger } from './logger';
 import { SSH } from './ssh';
 import { ConfigManager } from './config-manager';
-import { escapeSpace } from './utils/string';
 import { parseTsUri } from './utils/uri';
 import { fileSorter } from './filesystem-provider';
 

--- a/src/utils/uri.ts
+++ b/src/utils/uri.ts
@@ -1,5 +1,4 @@
 import { Uri } from 'vscode';
-import { escapeSpace } from './string';
 
 export interface TsUri {
   address: string;
@@ -34,7 +33,7 @@ export function parseTsUri(uri: Uri): TsUri {
       let resourcePath = decodeURIComponent(pathSegments.join('/'));
 
       if (!resourcePath.startsWith('.')) {
-        resourcePath = `/${escapeSpace(resourcePath)}`;
+        resourcePath = `/${resourcePath}`;
       }
 
       return { address, tailnet: uri.authority, resourcePath };


### PR DESCRIPTION
We were escaping spaces while using that value directly in SFTP calls. This caused the escape character (`\`) to be included in the file/directory name. Additionally, if a space was included it would not be able to be deleted as it would issue the delete call to include the escape character.

Closes #231