### PR TITLE
feat(handler): hide mullvad nodes from list

### DIFF
--- a/tsrelay/handler/get_peers.go
+++ b/tsrelay/handler/get_peers.go
@@ -100,6 +100,10 @@ func (h *handler) getPeers(ctx context.Context, body io.Reader) (*getPeersRespon
 			continue
 		}
 
+		if strings.Contains(p.DNSName, "mullvad.ts.net") {
+			continue
+		}
+
 		serverName := p.HostName
 		if p.DNSName != "" {
 			parts := strings.SplitN(p.DNSName, ".", 2)


### PR DESCRIPTION
I suspect this is just a bug and not intended behaviour. This is a simple fix that hides all the Mullvad nodes from the `All machines` list.

Tested on macOS v15.0.1 using VSCode v1.94.2

Fixes #278