### PR TITLE
src/ssh: fix default username seting

### DIFF
--- a/src/ssh.ts
+++ b/src/ssh.ts
@@ -127,7 +127,10 @@ export class SSH {
   public sshHostnameWithUser(hostname: string) {
     const { hosts } = this.configManager?.config || {};
     const userForHost = hosts?.[hostname]?.user?.trim();
-    const defaultUser = vscode.workspace.getConfiguration('ssh').get<string>('defaultUser')?.trim();
+    const defaultUser = vscode.workspace
+      .getConfiguration('ssh')
+      .get<string>('defaultUsername')
+      ?.trim();
 
     const user = userForHost || defaultUser;
     return user ? `${user}@${hostname}` : hostname;

--- a/src/utils/host.ts
+++ b/src/utils/host.ts
@@ -7,7 +7,7 @@ export function getUsername(configManager: ConfigManager, hostname: string) {
   const userForHost = hosts?.[hostname]?.user?.trim();
   const defaultUser = vscode.workspace
     .getConfiguration('tailscale')
-    .get<string>('ssh.defaultUser')
+    .get<string>('ssh.defaultUsername')
     ?.trim();
 
   return userForHost || defaultUser || userInfo().username;


### PR DESCRIPTION
We were mistakenly checking `defaultUser` instead of `defaultUsername`